### PR TITLE
Avoid hash collision errors when loading PIL

### DIFF
--- a/fpdf/py3k.py
+++ b/fpdf/py3k.py
@@ -34,6 +34,7 @@ def hashpath(fn):
 
 # Check if PIL is available (tries importing both pypi version and corrected or manually installed versions).
 # Necessary for JPEG and GIF support.
+# TODO: Pillow support
 try:
     from PIL import Image
 except ImportError:

--- a/fpdf/py3k.py
+++ b/fpdf/py3k.py
@@ -35,13 +35,12 @@ def hashpath(fn):
 # Check if PIL is available (tries importing both pypi version and corrected or manually installed versions).
 # Necessary for JPEG and GIF support.
 try:
+    from PIL import Image
+except ImportError:
     try:
         import Image
-    except:
-        from PIL import Image
-        # TODO: Pillow support
-except ImportError:
-    Image = None
+    except ImportError:
+        Image = None
 
 try:
 	from HTMLParser import HTMLParser


### PR DESCRIPTION
This PR is related to https://github.com/reingart/pyfpdf/issues/3

In a project, if PIL is imported twice this error appears when PIL is imported through `import Image` (PIL should always be imported using `from PIL import Image`), thus this PR suggests to first try importing PIL using the `from ... import ...` syntax.

Python thinks indeed that it is importing two (or more) modules having the same name when using `import Image`. Moreover, the `AccessInit: hash collision: 3 for both 1 and 1` error is making Python crash.

Please review, thanks a lot