### PR TITLE
Fix bug with set_display_mode(<number>)

### DIFF
--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -13,6 +13,8 @@
 # * NOTE: 'I' and 'D' destinations are disabled, and simply print to STDOUT  *
 # ****************************************************************************
 
+from __future__ import division
+
 from datetime import datetime
 from functools import wraps
 import math
@@ -177,7 +179,11 @@ class FPDF(object):
         self.page_break_trigger=self.h-margin
 
     def set_display_mode(self, zoom,layout='continuous'):
-        "Set display mode in viewer"
+        """Set display mode in viewer
+        
+        The "zoom" argument may be 'fullpage', 'fullwidth', 'real',
+        'default', or a number, interpreted as a percentage."""
+        
         if(zoom=='fullpage' or zoom=='fullwidth' or zoom=='real' or zoom=='default' or not isinstance(zoom,basestring)):
             self.zoom_mode=zoom
         else:
@@ -1609,7 +1615,7 @@ class FPDF(object):
         elif(self.zoom_mode=='real'):
             self._out('/OpenAction [3 0 R /XYZ null null 1]')
         elif(not isinstance(self.zoom_mode,basestring)):
-            self._out('/OpenAction [3 0 R /XYZ null null '+(self.zoom_mode/100)+']')
+            self._out(sprintf('/OpenAction [3 0 R /XYZ null null %s]',self.zoom_mode/100))
         if(self.layout_mode=='single'):
             self._out('/PageLayout /SinglePage')
         elif(self.layout_mode=='continuous'):


### PR DESCRIPTION
As a side effect, this also fixes Google Code Issue 36, about using inches
and points as units.

Enables true division, available since Python 2.2. Also extends docstring to
clarify zoom parameter.

---

All of the tests pass as well as they did before (tried with Python 2.6, 2.7, 3.3, 3.4, Linux, Wine, Pillow, BIDI), so I am fairly confident that enabling true division doesn’t break anything.
