### PR TITLE
Test and fix the different modes of output()

### DIFF
--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -1095,24 +1095,25 @@ class FPDF(object):
                 dest='I'
             else:
                 dest='F'
-        if dest=='I':
-            print(self.buffer)
-        elif dest=='D':
-            print(self.buffer)
+        if PY3K:
+            # manage binary data as latin1 until PEP461 or similar is implemented
+            buffer = self.buffer.encode("latin1")
+        else:
+            buffer = self.buffer
+        if dest in ('I', 'D'):
+            # Python < 3 writes byte data transparently without "buffer"
+            stdout = getattr(sys.stdout, 'buffer', sys.stdout)
+            stdout.write(buffer)
         elif dest=='F':
             #Save to local file
             f=open(name,'wb')
             if(not f):
                 self.error('Unable to create output file: '+name)
-            if PY3K:
-                # manage binary data as latin1 until PEP461 or similar is implemented
-                f.write(self.buffer.encode("latin1"))
-            else:
-                f.write(self.buffer)
+            f.write(buffer)
             f.close()
         elif dest=='S':
             #Return as a string
-            return self.buffer
+            return buffer
         else:
             self.error('Incorrect output destination: '+dest)
 

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -1080,14 +1080,18 @@ class FPDF(object):
         self.set_x(x)
 
     def output(self, name='',dest=''):
-        "Output PDF to some destination"
+        """Output PDF to some destination
+        
+        By default the PDF is written to sys.stdout. If a name is given, the
+        PDF is written to a new file. If dest='S' is given, the PDF data is
+        returned as a byte string."""
+        
         #Finish document if necessary
         if(self.state<3):
             self.close()
         dest=dest.upper()
         if(dest==''):
             if(name==''):
-                name='doc.pdf'
                 dest='I'
             else:
                 dest='F'
@@ -1111,7 +1115,6 @@ class FPDF(object):
             return self.buffer
         else:
             self.error('Incorrect output destination: '+dest)
-        return ''
 
     def normalize_text(self, txt):
         "Check that text input is in the correct format/encoding"

--- a/tests/cover/test_output.py
+++ b/tests/cover/test_output.py
@@ -1,0 +1,59 @@
+"Test the various PDF output modes"
+
+from __future__ import with_statement
+
+#PyFPDF-cover-test:format=PDF
+#PyFPDF-cover-test:fn=output.pdf
+#PyFPDF-cover-test:hash=3996992652a230c26ffe8b5b7525aeb3
+
+import common
+from fpdf import FPDF
+
+import sys
+
+try:  # Python >= 2.6
+    bytes
+except NameError:  # Python 2.5
+    bytes = str
+
+@common.add_unittest
+def dotest(outputname, nostamp=True):
+    pdf = FPDF(unit="pt")
+    pdf._putinfo = lambda: common.test_putinfo(pdf)
+    pdf.add_page()
+    pdf.set_font("Times", size=12)
+    pdf.cell(0, 12, "Dummy content")
+    
+    # Get the PDF data the usual way via a real file
+    pdf.output(outputname)
+    with open(outputname, "rb") as file:
+        data = file.read(1000)
+        assert len(data) == 966, "Unexpected PDF file size"
+    
+    try:  # Python < 3 (Python 2.5 does not have the "io" module)
+        from cStringIO import StringIO
+        capture = StringIO()
+        detach = lambda: capture
+    except ImportError:  # Python >= 3.1
+        from io import TextIOWrapper, BytesIO
+        # Ensure that no text encoding is actually done
+        capture = TextIOWrapper(BytesIO(), "undefined")
+        detach = lambda: capture.detach()
+    
+    # Compare data when output() writes to stdout
+    original_stdout = sys.stdout
+    try:
+        sys.stdout = capture
+        pdf.output()
+        capture = detach()
+    finally:
+        sys.stdout = original_stdout
+    assert capture.getvalue() == data, "Unexpected stdout data"
+    
+    # Compare data when output() returns a byte string
+    returned = pdf.output(dest="S")
+    assert isinstance(returned, bytes), "output() should return bytes"
+    assert returned == data, "Unexpected PDF data returned"
+
+if __name__ == "__main__":
+    common.testmain(__file__, dotest)


### PR DESCRIPTION
There are three modes:

```python
pdf.output(filename)  # normal usage
pdf.output()  # write to stdout
data = pdf.output(dest='S')  # return buffer
```

The last two didn’t work properly in Python 3. This fixes them.
