### PR TITLE
Improved caching

### DIFF
--- a/docs/ReferenceManual.md
+++ b/docs/ReferenceManual.md
@@ -58,6 +58,7 @@
 This features not available in original FPDF and implemented after fork.
 
   * [DashedLine](reference/DashedLine.md) - draw a dashed line
+  * [SetCache](reference/SetCache.md) - change font caching behaviour
   * [SetStretching](reference/SetStretching.md) - set horizontal font stretching
   * [WriteHTML](reference/WriteHTML.md) - print text with HTML markup
 

--- a/docs/reference/AddFont.md
+++ b/docs/reference/AddFont.md
@@ -8,26 +8,28 @@ fpdf.add_font(family: str, style = '', fname = '', uni = False)
 
 Imports a TrueType, OpenType or Type1 font and makes it available.
 
-**Warning:** For !Type1 and legacy fonts it is necessary to generate a font definition file first with the `MakeFont` utility. This feature is currently deprecated in favour to TrueType unicode font support (whose are automatically processed with the `ttfonts.py` included utility).
+**Warning:** For !Type1 and legacy fonts it is necessary to generate a font 
+definition file first with the `MakeFont` utility. This feature is currently 
+deprecated in favour to TrueType unicode font support (whose are automatically 
+processed with the `ttfonts.py` included utility).
 
-**Note**: the font source files must be accessible. They are searched successively in (if this constants are defined):
+**Note**: the font source files must be accessible. They are searched 
+successively in (if this constants are defined):
 
   * `FPDF_FONTPATH` (by default, `font` folder in the fpdf package directory)
   * `SYSTEM_TTFONTS` (i.e. `C:\WINDOWS\FONTS`)
 
-If the file corresponding to the requested font is not found, the runtime exception _"TTF Font file not found: "_ is raised.
+If the file corresponding to the requested font is not found, the runtime 
+exception _"TTF Font file not found: "_ is raised.
 
 For more information, see [Unicode](../Unicode.md) support page.
 
-The method should be called before SetFont method is used, and the font will be available for the whole document.
+The method should be called before [SetFont](SetFont.md) method is used, and the
+font will be available for the whole document.
 
-**Note**: due font processing can occupy large amount of time some data are cached.
-
-Files created in same folder by default. This can be changed by `FPDF_CACHE_MODE` constant:
-
-  * 0 - (by default), store cache in the same folder as font file
-  * 1 - disable caching at all
-  * 2 - store cache files in `FPDF_CACHE_DIR` directory with cryptic names
+**Note**: due font processing can occupy large amount of time some data are 
+cached. Files created in same folder by default. For more information see
+[SetCache](SetCache.md).
 
 ### Parameters ###
 
@@ -38,26 +40,31 @@ style:
 > Font style. Deprecated, maintained only for backward compatibility.
 
 fname:
-> Font file name (i.e. `'DejaVuSansCondensed.ttf'`). You can specify a full path, if not, the file will be searched in `FPDF_FONTPATH` or `SYSTEM_TTFONTS`
+> Font file name (i.e. `'DejaVuSansCondensed.ttf'`). You can specify a full 
+path, if not, the file will be searched in `FPDF_FONTPATH` or `SYSTEM_TTFONTS`
 
 uni:
-> TTF Unicode flag (if set to `True`, TrueType font subset embedding will be enabled and text will be treated as `utf8` by default).
+> TTF Unicode flag (if set to `True`, TrueType font subset embedding will be 
+enabled and text will be treated as `utf8` by default).
 
-You must _not call_ AddFont for PDF Standard Latin-1 fonts (Courier, Helvetica, Times, Symbol, Zapfdingbats), use SetFont directly in that case.
+You must _not call_ AddFont for PDF Standard Latin-1 fonts (Courier, Helvetica, 
+Times, Symbol, Zapfdingbats), use SetFont directly in that case.
 
-Calling this method with uni=False is discouraged as legacy font support is complex and deprecated.
+Calling this method with uni=False is discouraged as legacy font support is 
+complex and deprecated.
 
 
 ### Example ###
 
 ```python
 # Add a Unicode free font
-pdf.add_font('DejaVu', '', 'DejaVuSansCondensed.ttf', uni=True)
+pdf.add_font('DejaVu', '', 'DejaVuSansCondensed.ttf', uni = True)
 
 # Add a Unicode system font (using full path)
-pdf.add_font('sysfont', '', r"c:\WINDOWS\Fonts\arial.ttf", uni=True)
+pdf.add_font('sysfont', '', r"c:\WINDOWS\Fonts\arial.ttf", uni =T rue)
 ```
 
 ### See also ###
 
-[SetFont](SetFont.md), [SetFontSize](SetFontSize.md), [Cell](Cell.md), [MultiCell](MultiCell.md), [Write](Write.md).
+[SetFont](SetFont.md), [SetCache](SetCache.md), [SetFontSize](SetFontSize.md), 
+[Cell](Cell.md), [MultiCell](MultiCell.md), [Write](Write.md).

--- a/docs/reference/SetCache.md
+++ b/docs/reference/SetCache.md
@@ -1,0 +1,74 @@
+## SetCache ##
+
+```python
+fpdf.set_cache(cache)
+```
+
+### Description ###
+
+This method change caching mechanism for current fpdf class instance.
+If this method not called before [AddFont](AddFont.md) cached files are
+created in same folder with fonts.
+
+**Note**: Prior version `1.7.3` caching behaviour can be changed 
+by `FPDF_CACHE_MODE` constant:
+
+  * 0 - (by default), store cache in the same folder as font file
+  * 1 - disable caching at all
+  * 2 - store cache files in `FPDF_CACHE_DIR` directory with cryptic names
+
+### Parameters ###
+
+cache:
+> This value can be int, str or cache class.
+>> * int instance:
+>>>  * 0 - standard cache behaviour
+>>>  * 1 - do not create or load cache files
+>> * str instance - path to cache folder
+>> * cache instance - caching class (see Builtin cache classes)
+
+### Builtin cache classes ###
+
+#### NoneCache ####
+
+This class are base for all other classes. Instanced when `cache` parameter is
+`1`.
+
+ * `__init__(font_dir = None, system_fonts = None)` - constructor, `font_dir`
+   and `system_fonts` are used to search font by its name.
+ * `find_font(fname)` - return full path to font if exists
+ * `cache_for(fname, ext = ".pkl")` - return full name of cache file, with
+    specified extension, or None if not applicable
+
+#### StdCache ####
+
+This is default class instanted with fpdf library by default and applied to all
+instances of FPDF class. `font_dir` are set to `FPDF_FONT_DIR` and 
+`system_fonts` are set to `SYSTEM_TTFONTS`. Instanced when `cache` parameter is
+`0`.
+
+ * `load_cache(filename, ttf = None)` - load cached data, with optional check 
+    TTF filename
+ * `save_cache(filename, data, ttf = None)` - save cached data, with optional
+    TTF filename
+
+#### HashCache ####
+
+This class can be used to store all cache in one folder, where full font path 
+encoded as hash. Instanced when `cache` parameter is `str` type.
+
+### Example ###
+
+For complex example refer to `tests/cover/test_cache_cls.py`.
+
+```python
+pdf = FPDF('P', 'mm', (100, 150))
+# disable cache
+pdf.set_cache(1)
+# add font, no .pkl files
+pdf.add_font('DejaVu', '', "./fonts/DejaVuSans.ttf", uni = True) 
+```
+
+### See also ###
+
+[AddFont](AddFont.md), [SetFont](SetFont.md).

--- a/fpdf/__init__.py
+++ b/fpdf/__init__.py
@@ -7,6 +7,7 @@ __license__ = "LGPL 3.0"
 __version__ = "1.7.2"
 
 from .fpdf import FPDF, FPDF_FONT_DIR, FPDF_VERSION, SYSTEM_TTFONTS, set_global, FPDF_CACHE_MODE, FPDF_CACHE_DIR
+from .cache import StdCache, NoneCache, HashCache
 try:
     from .html import HTMLMixin
 except ImportError:

--- a/fpdf/cache.py
+++ b/fpdf/cache.py
@@ -1,0 +1,106 @@
+#******************************************************************************
+# Caching classes
+# 
+# This classes are provided to maintain caching mechanism for python FPDF port
+# and allow to extend standard behaviour.
+# 
+# Version:  1.00
+# Date:     2015-03-24
+# Author:   Roman Kharin <romiq.kh@gmail.com>
+# License:  LGPL
+# Copyright (c) Roman Kharin, 2015
+#******************************************************************************
+
+import os, sys
+
+from .py3k import pickle, hashpath
+
+CACHE_VERSION = 3 # This constant will be updated with any format changes
+
+def instance_cache(cache_mode, cache_dir = None, font_dir = None, 
+        system_fonts = None): # match with FPDF_CACHE_MODE
+    if cache_mode == 0: # 
+        return StdCache(font_dir = font_dir, system_fonts = system_fonts)
+    elif (cache_mode == 1) or (cache_mode == 2 and not cache_dir):
+        return NoneCache(font_dir = font_dir, system_fonts = system_fonts)
+    elif cache_mode == 2:
+        return HashCache(font_dir = font_dir, system_fonts = system_fonts,
+            cache_dir = cache_dir)
+    else:
+        raise Exception("Unknown FPDF_CACHE_MODE mode")
+
+class NoneCache:
+    """Do not store file cache (FPDF_CACHE_MODE == 1)"""
+    def __init__(self, font_dir = None, system_fonts = None):
+        self.font_dir = font_dir
+        self.system_fonts = system_fonts
+
+    def find_font(self, fname):
+        ttffilename = None
+        if os.path.exists(fname):
+            return fname
+        if (self.font_dir and
+            os.path.exists(os.path.join(self.font_dir, fname))):
+            return os.path.join(self.font_dir, fname)
+        if (self.system_fonts and
+            os.path.exists(os.path.join(self.system_fonts, fname))):
+            return os.path.join(self.system_fonts, fname)
+        return None
+
+    def cache_for(self, fname, ext = ".pkl"):
+        return None
+        
+    def load_cache(self, filename, ttf = None):
+        return None
+        
+    def save_cache(self, filename, data, ttf = None):
+        return
+        
+class StdCache(NoneCache):
+    """Store cache files in pickle format in same folder with fonts 
+    (FPDF_CACHE_MODE == 0)"""
+
+    def load_cache(self, filename, ttf = None):
+        "Load raw object, or None if no cache found or incompatible"
+        if not filename:
+            return None
+        try:
+            with open(filename, "rb") as fh:
+                data = pickle.load(fh)
+                assert data["CACHE_VERSION"] == CACHE_VERSION
+                assert data["SYS_VERSION"] == tuple(sys.version_info)
+                if ttf:
+                    assert data["TTF_PATH"] == ttf
+                return data
+        except (IOError, pickle.UnpicklingError, ValueError, AssertionError):
+            return None
+
+    def save_cache(self, filename, data, ttf = None):
+        "Save raw object"
+        if not filename:
+            return None
+        try:
+            with open(filename, "wb") as fh:
+                data["CACHE_VERSION"] = CACHE_VERSION
+                data["SYS_VERSION"] = tuple(sys.version_info)
+                if ttf:
+                    data["TTF_PATH"] = ttf
+                pickle.dump(data, fh)
+        except Exception as e:  
+            return None
+        
+    def cache_for(self, fname, ext = ".pkl"):
+        return os.path.splitext(fname)[0] + ext
+        
+class HashCache(StdCache):
+    "Store cache files in specified folder (FPDF_CACHE_MODE == 2)"
+    def __init__(self, font_dir = None, system_fonts = None, cache_dir = None):
+        StdCache.__init__(self, font_dir, system_fonts)
+        self.cache_dir = cache_dir
+        assert self.cache_dir is not None, "Cache dir must be specified"
+    
+    def cache_for(self, fname, ext = ".pkl"):
+        fname = os.path.abspath(fname)
+        return os.path.join(self.cache_dir, \
+                    hashpath(fname) + ext)
+    

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -20,11 +20,13 @@ from functools import wraps
 import math
 import errno
 import os, sys, zlib, struct, re, tempfile, struct
+import warnings
 
 from .ttfonts import TTFontFile
 from .fonts import fpdf_charwidths
 from .php import substr, sprintf, print_r, UTF8ToUTF16BE, UTF8StringToArray
-from .py3k import PY3K, pickle, urlopen, Image, basestring, unicode, exception, b, hashpath
+from .py3k import PY3K, pickle, urlopen, Image, basestring, unicode, exception, b
+from .cache import instance_cache, NoneCache
 
 # Global variables
 FPDF_VERSION = '1.7.2'
@@ -32,11 +34,23 @@ FPDF_FONT_DIR = os.path.join(os.path.dirname(__file__),'font')
 FPDF_CACHE_MODE = 0 # 0 - in same folder, 1 - none, 2 - hash
 FPDF_CACHE_DIR = None
 SYSTEM_TTFONTS = None
+FPDF_CACHE = None
 
-
+def change_cache():
+    global FPDF_CACHE, FPDF_CACHE_MODE, FPDF_CACHE_DIR
+    global FPDF_FONT_DIR, SYSTEM_TTFONTS
+    FPDF_CACHE = instance_cache(cache_mode = FPDF_CACHE_MODE, 
+        cache_dir = FPDF_CACHE_DIR, font_dir = FPDF_FONT_DIR, 
+        system_fonts = SYSTEM_TTFONTS)
+change_cache()
+    
 def set_global(var, val):
+    warnings.warn("Setting global wariable are deprecated and will be removed",
+        DeprecationWarning)
     globals()[var] = val
-
+    if var in ["FPDF_CACHE_MODE", "FPDF_CACHE_DIR"]:
+        change_cache()
+        
 def load_cache(filename):
     """Return unpickled object, or None if cache unavailable"""
     if not filename:
@@ -149,6 +163,9 @@ class FPDF(object):
         self.set_compression(1)
         # Set default PDF version number
         self.pdf_version='1.3'
+
+        # Set default cache to None
+        self.cache = None
 
     def check_page(fn):
         "Decorator to protect drawing methods"
@@ -472,26 +489,15 @@ class FPDF(object):
             # Font already added!
             return
         if (uni):
-            global SYSTEM_TTFONTS, FPDF_CACHE_MODE, FPDF_CACHE_DIR
-            if os.path.exists(fname):
-                ttffilename = fname
-            elif (FPDF_FONT_DIR and
-                os.path.exists(os.path.join(FPDF_FONT_DIR, fname))):
-                ttffilename = os.path.join(FPDF_FONT_DIR, fname)
-            elif (SYSTEM_TTFONTS and
-                os.path.exists(os.path.join(SYSTEM_TTFONTS, fname))):
-                ttffilename = os.path.join(SYSTEM_TTFONTS, fname)
-            else:
+            global FPDF_CACHE
+            cache = self.cache or FPDF_CACHE
+            ttffilename = cache.find_font(fname)
+            if not ttffilename:
                 raise RuntimeError("TTF Font file not found: %s" % fname)
             name = ''
-            if FPDF_CACHE_MODE == 0:
-                unifilename = os.path.splitext(ttffilename)[0] + '.pkl'
-            elif FPDF_CACHE_MODE == 2:                
-                unifilename = os.path.join(FPDF_CACHE_DIR, \
-                    hashpath(ttffilename) + ".pkl")
-            else:
-                unifilename = None
-            font_dict = load_cache(unifilename)
+            unifilename = cache.cache_for(ttffilename)
+            font_dict = cache.load_cache(unifilename, 
+                os.path.abspath(ttffilename))
             if font_dict is None:
                 ttf = TTFontFile()
                 ttf.getMetrics(ttffilename)
@@ -521,14 +527,8 @@ class FPDF(object):
                     'originalsize': os.stat(ttffilename).st_size,
                     'cw': ttf.charWidths,
                     }
-                if unifilename:
-                    try:
-                        fh = open(unifilename, "wb")
-                        pickle.dump(font_dict, fh)
-                        fh.close()
-                    except IOError:
-                        if not exception().errno == errno.EACCES:
-                            raise  # Not a permission error.
+                cache.save_cache(unifilename, font_dict, 
+                    os.path.abspath(ttffilename))
                 del ttf
             if hasattr(self,'str_alias_nb_pages'):
                 sbarr = list(range(0,57))   # include numbers in the subset!
@@ -1127,6 +1127,19 @@ class FPDF(object):
             txt = txt.encode('latin1')
         return txt
 
+    def set_cache(self, cache):
+        "Change cache"
+        global FPDF_FONT_DIR, SYSTEM_TTFONTS
+        if isinstance(cache, int): # 0 - same folder, 1 - none
+            self.cache = instance_cache(cache, 
+                    cache_dir = None, font_dir = FPDF_FONT_DIR, 
+                    system_fonts = SYSTEM_TTFONTS)
+        elif isinstance(cache, str): # hash path
+            self.cache = instance_cache(2, 
+                    cache_dir = cache, font_dir = FPDF_FONT_DIR, 
+                    system_fonts = SYSTEM_TTFONTS)
+        else:
+            self.cache = cache
 
     def _dochecks(self):
         #Check for locale-related bug
@@ -1426,11 +1439,14 @@ class FPDF(object):
                 self.mtd(font)
 
     def _putTTfontwidths(self, font, maxUni):
+        global FPDF_CACHE
+        cache = self.cache or FPDF_CACHE
         if font['unifilename']:
             cw127fname = os.path.splitext(font['unifilename'])[0] + '.cw127.pkl'
         else:
             cw127fname = None
-        font_dict = load_cache(cw127fname)
+        font_dict = cache.load_cache(cw127fname)
+        font_data = font_dict
         if font_dict is None:    
             rangeid = 0
             range_ = {}
@@ -1452,21 +1468,15 @@ class FPDF(object):
         # for each character
         subset = set(font['subset'])
         for cid in range(startcid, cwlen):
-            if cid == 128 and cw127fname and not os.path.exists(cw127fname):
-                try:
-                    fh = open(cw127fname, "wb")
-                    font_dict = {}
-                    font_dict['rangeid'] = rangeid
-                    font_dict['prevcid'] = prevcid
-                    font_dict['prevwidth'] = prevwidth
-                    font_dict['interval'] = interval
-                    font_dict['range_interval'] = range_interval
-                    font_dict['range'] = range_
-                    pickle.dump(font_dict, fh)
-                    fh.close()
-                except IOError:
-                    if not exception().errno == errno.EACCES:
-                        raise  # Not a permission error.
+            if cid == 128 and cw127fname and font_dict is None:
+                font_dict = {}
+                font_dict['rangeid'] = rangeid
+                font_dict['prevcid'] = prevcid
+                font_dict['prevwidth'] = prevwidth
+                font_dict['interval'] = interval
+                font_dict['range_interval'] = range_interval
+                font_dict['range'] = range_
+                cache.save_cache(cw127fname, font_dict)
             if cid > 255 and (cid not in subset): #
                 continue
             width = font['cw'][cid]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ pages:
 - ["reference/Rect.md", "Reference manual", "Rect"]
 - ["reference/SetAuthor.md", "Reference manual", "SetAuthor"]
 - ["reference/SetAutoPageBreak.md", "Reference manual", "SetAutoPageBreak"]
+- ["reference/SetCache.md", "Reference manual", "SetCache"]
 - ["reference/SetCompression.md", "Reference manual", "SetCompression"]
 - ["reference/SetCreator.md", "Reference manual", "SetCreator"]
 - ["reference/SetDisplayMode.md", "Reference manual", "SetDisplayMode"]

--- a/tests/cover/test_cache_cls.py
+++ b/tests/cover/test_cache_cls.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-"Test caching"
+"Test new caching classes"
 
 #PyFPDF-cover-test:res=font/DejaVuSansCondensed.ttf
 #PyFPDF-cover-test:res=font/DejaVuSans.ttf
@@ -9,10 +9,12 @@ import common
 import fpdf
 
 import os, shutil, time
+import gzip
 
-def testfile(f1, f2):
+def testfile(f1, f2, cache):
     # create pdf
     pdf = fpdf.FPDF()
+    pdf.set_cache(cache)
     if f1:
         pdf.add_font('DejaVuSansCondensed', '', f1, uni = True)
     if f2:
@@ -40,7 +42,34 @@ def hashfn(fn):
     else:
         h.update(fn)
     return h.hexdigest()
-  
+
+class CacheGzip(fpdf.HashCache):
+    # Load cached        
+    def load_cache(self, filename, ttf = None):
+        if not filename:
+            return None
+        try:
+            with gzip.GzipFile(filename + ".gz", "rb") as fh:
+                data = fpdf.py3k.pickle.load(fh)
+                if ttf:
+                    assert data["TTF_PATH"] == ttf
+                return data
+        except (IOError, ValueError, AssertionError):
+            return None
+
+    # Note: if standard cache loaded will work, then save_cache 
+    #   will not be called
+    def save_cache(self, filename, data, ttf = None):
+        if not filename:
+            return None
+        try:
+            with gzip.GzipFile(filename + ".gz", "wb", compresslevel = 1) as fh:
+                if ttf:
+                    data["TTF_PATH"] = ttf
+                fpdf.py3k.pickle.dump(data, fh)
+        except Exception as e:  
+            return None
+        
 
 @common.add_unittest
 def dotest(outputname, nostamp):
@@ -67,16 +96,15 @@ def dotest(outputname, nostamp):
     f2 = os.path.join(cachepath, "DejaVuSans.ttf")
 
     # --- normal cache mode ---
-    fpdf.set_global("FPDF_CACHE_MODE", 0)
     # first load
     t0 = time.time()
-    pdf = testfile(f1, f2)
+    pdf = testfile(f1, f2, 0)
     t1 = time.time()
     assert os.path.exists(f1[:-3] + "pkl"), "Pickle for DejaVuSansCondensed not found"
     assert os.path.exists(f2[:-3] + "pkl"), "Pickle for DejaVuSans not found"
     # load cached
     t2 = time.time()
-    pdf = testfile(f1, f2)
+    pdf = testfile(f1, f2, 0)
     t3 = time.time()
     if not nostamp:
         common.log("Cache fonts:  ", t1 - t0)
@@ -92,14 +120,13 @@ def dotest(outputname, nostamp):
     assert os.path.exists(f2[:-3] + "cw127.pkl"), "Unnecessary cw127 for DejaVuSans"
         
     # --- disable cache reading ---
-    fpdf.set_global("FPDF_CACHE_MODE", 1)
     # put garbage data to cache files - fpdf should not read pkl
     trashfile(f1[:-3] + "pkl")
     trashfile(f2[:-3] + "pkl")
     trashfile(f2[:-3] + "cw127.pkl")
     # test same file
     t0 = time.time()
-    pdf = testfile(f1, f2)
+    pdf = testfile(f1, f2, 1)
     t1 = time.time()
     # remove pkl files
     os.remove(f1[:-3] + "pkl")
@@ -107,7 +134,7 @@ def dotest(outputname, nostamp):
     os.remove(f2[:-3] + "cw127.pkl")
     # test reload
     t2 = time.time()
-    pdf = testfile(f1, f2)
+    pdf = testfile(f1, f2, 1)
     t3 = time.time()
     if not nostamp:
         common.log("No cache 1st: ", t1 - t0)
@@ -123,30 +150,61 @@ def dotest(outputname, nostamp):
     assert not os.path.exists(f2[:-3] + "cw127.pkl"), "Unnecessary file DejaVuSans.127.pkl"
 
     # --- hash cache ---
-    fpdf.set_global("FPDF_CACHE_MODE", 2)
-    fpdf.set_global("FPDF_CACHE_DIR", hashpath)
     t0 = time.time()
-    pdf = testfile(f1, f2)
+    pdf = testfile(f1, f2, hashpath)
     t1 = time.time()
     assert not os.path.exists(f1[:-3] + "pkl"), "Misplaced file DejaVuSansCondensed.pkl"
     assert not os.path.exists(f2[:-3] + "pkl"), "Misplaced file DejaVuSans.pkl"
     # load cached
     t2 = time.time()
-    pdf = testfile(f1, f2)
+    pdf = testfile(f1, f2, hashpath)
     t3 = time.time()
     # test reload
     if not nostamp:
         common.log("Hash load 1st:", t1 - t0)
         common.log("Hash load 2nd:", t3 - t2)
     # check hash
-    assert os.path.exists(os.path.join(hashpath, hashfn(f1) + ".pkl")), "Cached pickle for DejaVuSansCondensed not found"
-    assert os.path.exists(os.path.join(hashpath, hashfn(f2) + ".pkl")), "Cached pickle for DejaVuSans not found"            
+    h1 = os.path.join(hashpath, hashfn(f1) + ".pkl")
+    h2 = os.path.join(hashpath, hashfn(f2) + ".pkl")
+    assert os.path.exists(h1), "Cached pickle for DejaVuSansCondensed not found"
+    assert os.path.exists(h2), "Cached pickle for DejaVuSans not found"            
     pdf.add_page()
     pdf.write(5, "Хешировали, хешировали, да выдохешировали.")
     pdf.write(10, "Hello")
     pdf.output(os.path.join(cachepath, "pdf2.pdf"), "F")
-    assert not os.path.exists(os.path.join(hashpath, hashfn(f1) + ".cw127.pkl")), "Cachecd cw127 for DejaVuSansCondensed not found"
-    assert os.path.exists(os.path.join(hashpath, hashfn(f2) + ".cw127.pkl")), "Unnecessary cached cw127 for DejaVuSans"
+    assert not os.path.exists(h1[:-3] + "cw127.pkl"), "Unnecessary cached cw127 for DejaVuSansCondensed "
+    assert os.path.exists(h2[:-3] + "cw127.pkl"), "Cached cw127 for DejaVuSans not found"
+    
+
+    # --- test gzip ---
+    # remove cached files from HashCache
+    os.remove(h1)
+    os.remove(h2)
+    os.remove(h2[:-3] + "cw127.pkl")
+    cgz = CacheGzip(cache_dir = hashpath)
+    t0 = time.time()
+    pdf = testfile(f1, f2, cgz)
+    t1 = time.time()
+    assert not os.path.exists(h1), "Misplaced hash file DejaVuSansCondensed.pkl"
+    assert not os.path.exists(h2), "Misplaced hash file DejaVuSans.pkl"
+
+    # load cached
+    t2 = time.time()
+    pdf = testfile(f1, f2, cgz)
+    t3 = time.time()
+    # test reload
+    if not nostamp:
+        common.log("Gzip hash 1st:", t1 - t0)
+        common.log("Gzip hash 2nd:", t3 - t2)
+    # check hash
+    assert os.path.exists(h1 + ".gz"), "Gzip cached pickle for DejaVuSansCondensed not found"
+    assert os.path.exists(h2 + ".gz"), "Gzip cached pickle for DejaVuSans not found"            
+    pdf.add_page()
+    pdf.write(5, "Сжимай! Сжимаю, сжал")
+    pdf.write(10, "Hello")
+    pdf.output(os.path.join(cachepath, "pdf3.pdf"), "F")
+    assert not os.path.exists(h1[:-3] + "cw127.pkl.gz"), "Unnecessary gzip cached cw127 for DejaVuSansCondensed "
+    assert os.path.exists(h2[:-3] + "cw127.pkl.gz"), "Gzip cached cw127 for DejaVuSans not found"
 
 if __name__ == "__main__":
     common.testmain(__file__, dotest)


### PR DESCRIPTION
This PR add caching mechanism for FPDF.
By default users see no changes, but with fpdf.set_cache function behaviour can be saved in any format in any place (tests/cover/test_cache_cls.py). Also docs and new test.