### PR TITLE
Improve Python 3 compatibility and fix warnings

### DIFF
--- a/examples/form.py
+++ b/examples/form.py
@@ -1,4 +1,6 @@
 # -*- coding: iso-8859-1 -*-
+from __future__ import with_statement
+
 import sys,os
 from fpdf import FPDF
 
@@ -9,19 +11,20 @@ class Form:
                 'align','text','priority')
         # parse form format file and create fields dict
         self.fields = {}
-        for linea in open(infile).readlines():
-            kargs = {}
-            for i,v in enumerate(linea.split(";")):
-                if not v.startswith("'"): 
-                    v = v.replace(",",".")
-                else:
-                    v = v#.decode('latin1')
-                if v=='':
-                    v = None
-                else:
-                    v = eval(v.strip())
-                kargs[keys[i]] = v
-            self.fields[kargs['name'].lower()] = kargs
+        with open(infile) as file:
+            for linea in file.readlines():
+                kargs = {}
+                for i,v in enumerate(linea.split(";")):
+                    if not v.startswith("'"): 
+                        v = v.replace(",",".")
+                    else:
+                        v = v#.decode('latin1')
+                    if v=='':
+                        v = None
+                    else:
+                        v = eval(v.strip())
+                    kargs[keys[i]] = v
+                self.fields[kargs['name'].lower()] = kargs
         self.handlers = {'T': self.text, 'L': self.line, 'I': self.image, 
                          'B': self.rect, 'BC': self.barcode}
 

--- a/examples/simple-csv-invoice.py
+++ b/examples/simple-csv-invoice.py
@@ -1,4 +1,6 @@
 # -*- coding: iso-8859-1 -*-
+from __future__ import with_statement
+
 import sys, os
 sys.path.append("..")
 import fpdf
@@ -13,10 +15,11 @@ items = [
 pdf = fpdf.FPDF()
 pdf.add_page();
 pdf.set_font('Arial','B',16);
-for line in open("simple-csv-invoice.txt").readlines():
-   sys.stdout.write(line)
-   args = eval(line.strip())
-   pdf.text(x=args[0],y=args[1],txt=str(args[2]));
+with open("simple-csv-invoice.txt") as file:
+   for line in file.readlines():
+      sys.stdout.write(line)
+      args = eval(line.strip())
+      pdf.text(x=args[0],y=args[1],txt=str(args[2]));
 
 pdf.output(r"./invoice.pdf","F")
 import sys

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -546,7 +546,7 @@ class FPDF(object):
                                         'type': "TTF", 'ttffile': ttffilename}
             self.font_files[fname] = {'type': "TTF"}
         else:
-            fontfile = open(fname)
+            fontfile = open(fname, 'rb')
             try:
                 font_dict = pickle.load(fontfile)
             finally:

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -13,7 +13,7 @@
 # * NOTE: 'I' and 'D' destinations are disabled, and simply print to STDOUT  *
 # ****************************************************************************
 
-from __future__ import division
+from __future__ import division, with_statement
 
 from datetime import datetime
 from functools import wraps
@@ -523,9 +523,8 @@ class FPDF(object):
                     }
                 if unifilename:
                     try:
-                        fh = open(unifilename, "wb")
-                        pickle.dump(font_dict, fh)
-                        fh.close()
+                        with open(unifilename, "wb") as fh:
+                            pickle.dump(font_dict, fh)
                     except IOError:
                         if not exception().errno == errno.EACCES:
                             raise  # Not a permission error.
@@ -546,11 +545,8 @@ class FPDF(object):
                                         'type': "TTF", 'ttffile': ttffilename}
             self.font_files[fname] = {'type': "TTF"}
         else:
-            fontfile = open(fname, 'rb')
-            try:
+            with open(fname, 'rb') as fontfile:
                 font_dict = pickle.load(fontfile)
-            finally:
-                fontfile.close()
             self.fonts[fontkey] = {'i': len(self.fonts)+1}
             self.fonts[fontkey].update(font_dict)
             diff = font_dict.get('diff')
@@ -607,7 +603,8 @@ class FPDF(object):
                     name=os.path.join(FPDF_FONT_DIR,family)
                     if(family=='times' or family=='helvetica'):
                         name+=style.lower()
-                    exec(compile(open(name+'.font').read(), name+'.font', 'exec'))
+                    with open(name+'.font') as file:
+                        exec(compile(file.read(), name+'.font', 'exec'))
                     if fontkey not in fpdf_charwidths:
                         self.error('Could not include font metric file for'+fontkey)
                 i=len(self.fonts)+1
@@ -1106,11 +1103,8 @@ class FPDF(object):
             stdout.write(buffer)
         elif dest=='F':
             #Save to local file
-            f=open(name,'wb')
-            if(not f):
-                self.error('Unable to create output file: '+name)
-            f.write(buffer)
-            f.close()
+            with open(name,'wb') as f:
+                f.write(buffer)
         elif dest=='S':
             #Return as a string
             return buffer
@@ -1225,12 +1219,8 @@ class FPDF(object):
                 #Font file embedding
                 self._newobj()
                 self.font_files[name]['n']=self.n
-                font=''
-                f=open(self._getfontpath()+name,'rb',1)
-                if(not f):
-                    self.error('Font file not found')
-                font=f.read()
-                f.close()
+                with open(self._getfontpath()+name,'rb',1) as f:
+                    font=f.read()
                 compressed=(substr(name,-2)=='.z')
                 if(not compressed and 'length2' in info):
                     header=(ord(font[0])==128)
@@ -1454,16 +1444,15 @@ class FPDF(object):
         for cid in range(startcid, cwlen):
             if cid == 128 and cw127fname and not os.path.exists(cw127fname):
                 try:
-                    fh = open(cw127fname, "wb")
-                    font_dict = {}
-                    font_dict['rangeid'] = rangeid
-                    font_dict['prevcid'] = prevcid
-                    font_dict['prevwidth'] = prevwidth
-                    font_dict['interval'] = interval
-                    font_dict['range_interval'] = range_interval
-                    font_dict['range'] = range_
-                    pickle.dump(font_dict, fh)
-                    fh.close()
+                    with open(cw127fname, "wb") as fh:
+                        font_dict = {}
+                        font_dict['rangeid'] = rangeid
+                        font_dict['prevcid'] = prevcid
+                        font_dict['prevwidth'] = prevwidth
+                        font_dict['interval'] = interval
+                        font_dict['range_interval'] = range_interval
+                        font_dict['range'] = range_
+                        pickle.dump(font_dict, fh)
                 except IOError:
                     if not exception().errno == errno.EACCES:
                         raise  # Not a permission error.
@@ -1735,6 +1724,7 @@ class FPDF(object):
 
     def _parsejpg(self, filename):
         # Extract info from a JPEG file
+        f = None
         try:
             f = open(filename, 'rb')
             while True:
@@ -1758,12 +1748,14 @@ class FPDF(object):
                         colspace = 'DeviceRGB' if layers == 3 else ('DeviceCMYK' if layers == 4 else 'DeviceGray')
                         break
         except Exception:
+            if f:
+                f.close()
             self.error('Missing or incorrect image file: %s. error: %s' % (filename, str(exception())))
 
-        # Read whole file from the start
-        f.seek(0)
-        data = f.read()
-        f.close()
+        with f:
+            # Read whole file from the start
+            f.seek(0)
+            data = f.read()
         return {'w':width,'h':height,'cs':colspace,'bpc':bpc,'f':'DCTDecode','data':data}
 
     def _parsegif(self, filename):
@@ -1776,9 +1768,9 @@ class FPDF(object):
             self.error('Missing or incorrect image file: %s. error: %s' % (filename, str(exception())))
         else:
             # Use temporary file
-            f = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
-            tmp = f.name
-            f.close()
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".png") as \
+                    f:
+                tmp = f.name
             if "transparency" in im.info:
                 im.save(tmp, transparency = im.info['transparency'])
             else:
@@ -1793,8 +1785,6 @@ class FPDF(object):
                f = urlopen(name)
         else:
             f=open(name,'rb')
-        if(not f):
-            self.error("Can't open image file: "+name)
         #Check signature
         magic = f.read(8).decode("latin1")
         signature = '\x89'+'PNG'+'\r'+'\n'+'\x1a'+'\n'

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -1536,7 +1536,7 @@ class FPDF(object):
             self._out('/Width '+str(info['w']))
             self._out('/Height '+str(info['h']))
             if(info['cs']=='Indexed'):
-                self._out('/ColorSpace [/Indexed /DeviceRGB '+str(int(len(info['pal'])/3)-1)+' '+str(self.n+1)+' 0 R]')
+                self._out('/ColorSpace [/Indexed /DeviceRGB '+str(len(info['pal'])//3-1)+' '+str(self.n+1)+' 0 R]')
             else:
                 self._out('/ColorSpace /'+info['cs'])
                 if(info['cs']=='DeviceCMYK'):

--- a/fpdf/html.py
+++ b/fpdf/html.py
@@ -79,7 +79,7 @@ class HTML2FPDF(HTMLParser):
             else:
                 l = [self.td.get('width','240')]
             w = sum([self.width2mm(length) for length in l])
-            h = int(self.td.get('height', 0)) / 4 or self.h*1.30
+            h = int(self.td.get('height', 0)) // 4 or self.h*1.30
             self.table_h = h
             border = int(self.table.get('border', 0))
             if not self.th:

--- a/fpdf/template.py
+++ b/fpdf/template.py
@@ -2,6 +2,8 @@
 
 "PDF Template Helper for FPDF.py"
 
+from __future__ import with_statement
+
 __author__ = "Mariano Reingart <reingart@gmail.com>"
 __copyright__ = "Copyright (C) 2010 Mariano Reingart"
 __license__ = "LGPL 3.0"
@@ -45,19 +47,20 @@ class Template:
             f = open(infile, 'rb')
         else:
             f = open(infile)
-        for row in csv.reader(f, delimiter=delimiter):
-            kargs = {}
-            for i,v in enumerate(row):
-                if not v.startswith("'") and decimal_sep!=".": 
-                    v = v.replace(decimal_sep,".")
-                else:
-                    v = v
-                if v=='':
-                    v = None
-                else:
-                    v = eval(v.strip())
-                kargs[keys[i]] = v
-            self.elements.append(kargs)
+        with f:
+            for row in csv.reader(f, delimiter=delimiter):
+                kargs = {}
+                for i,v in enumerate(row):
+                    if not v.startswith("'") and decimal_sep!=".": 
+                        v = v.replace(decimal_sep,".")
+                    else:
+                        v = v
+                    if v=='':
+                        v = None
+                    else:
+                        v = eval(v.strip())
+                    kargs[keys[i]] = v
+                self.elements.append(kargs)
         self.keys = [v['name'].lower() for v in self.elements]
 
     def add_page(self):

--- a/fpdf/ttfonts.py
+++ b/fpdf/ttfonts.py
@@ -16,6 +16,8 @@
 #                                                                              
 #******************************************************************************
 
+from __future__ import with_statement
+
 from struct import pack, unpack, unpack_from
 import re
 import warnings
@@ -75,26 +77,25 @@ class TTFontFile:
 
     def getMetrics(self, file):
         self.filename = file
-        self.fh = open(file,'rb')
-        self._pos = 0
-        self.charWidths = []
-        self.glyphPos = {}
-        self.charToGlyph = {}
-        self.tables = {}
-        self.otables = {}
-        self.ascent = 0
-        self.descent = 0
-        self.TTCFonts = {}
-        self.version = version = self.read_ulong()
-        if (version==0x4F54544F):
-            die("Postscript outlines are not supported")
-        if (version==0x74746366):
-            die("ERROR - TrueType Fonts Collections not supported")
-        if (version not in (0x00010000,0x74727565)):
-            die("Not a TrueType font: version=" + version)
-        self.readTableDirectory()
-        self.extractInfo()
-        self.fh.close()
+        with open(file,'rb') as self.fh:
+            self._pos = 0
+            self.charWidths = []
+            self.glyphPos = {}
+            self.charToGlyph = {}
+            self.tables = {}
+            self.otables = {}
+            self.ascent = 0
+            self.descent = 0
+            self.TTCFonts = {}
+            self.version = version = self.read_ulong()
+            if (version==0x4F54544F):
+                die("Postscript outlines are not supported")
+            if (version==0x74746366):
+                die("ERROR - TrueType Fonts Collections not supported")
+            if (version not in (0x00010000,0x74727565)):
+                die("Not a TrueType font: version=" + version)
+            self.readTableDirectory()
+            self.extractInfo()
     
     def readTableDirectory(self, ):
         self.numTables = self.read_ushort()
@@ -456,346 +457,344 @@ class TTFontFile:
 
     def makeSubset(self, file, subset):
         self.filename = file
-        self.fh = open(file ,'rb')
-        self._pos = 0
-        self.charWidths = []
-        self.glyphPos = {}
-        self.charToGlyph = {}
-        self.tables = {}
-        self.otables = {}
-        self.ascent = 0
-        self.descent = 0
-        self.skip(4)
-        self.maxUni = 0
-        self.readTableDirectory()
+        with open(file ,'rb') as self.fh:
+            self._pos = 0
+            self.charWidths = []
+            self.glyphPos = {}
+            self.charToGlyph = {}
+            self.tables = {}
+            self.otables = {}
+            self.ascent = 0
+            self.descent = 0
+            self.skip(4)
+            self.maxUni = 0
+            self.readTableDirectory()
 
-        #################/
-        # head - Font header table
-        #################/
-        self.seek_table("head")
-        self.skip(50) 
-        indexToLocFormat = self.read_ushort()
-        glyphDataFormat = self.read_ushort()
+            #################/
+            # head - Font header table
+            #################/
+            self.seek_table("head")
+            self.skip(50) 
+            indexToLocFormat = self.read_ushort()
+            glyphDataFormat = self.read_ushort()
 
-        #################/
-        # hhea - Horizontal header table
-        #################/
-        self.seek_table("hhea")
-        self.skip(32) 
-        metricDataFormat = self.read_ushort()
-        orignHmetrics = numberOfHMetrics = self.read_ushort()
+            #################/
+            # hhea - Horizontal header table
+            #################/
+            self.seek_table("hhea")
+            self.skip(32) 
+            metricDataFormat = self.read_ushort()
+            orignHmetrics = numberOfHMetrics = self.read_ushort()
 
-        #################/
-        # maxp - Maximum profile table
-        #################/
-        self.seek_table("maxp")
-        self.skip(4)
-        numGlyphs = self.read_ushort()
+            #################/
+            # maxp - Maximum profile table
+            #################/
+            self.seek_table("maxp")
+            self.skip(4)
+            numGlyphs = self.read_ushort()
 
-        #################/
-        # cmap - Character to glyph index mapping table
-        #################/
-        cmap_offset = self.seek_table("cmap")
-        self.skip(2)
-        cmapTableCount = self.read_ushort()
-        unicode_cmap_offset = 0
-        unicode_cmap_offset12 = 0
-        for i in range(cmapTableCount):
-            platformID = self.read_ushort()
-            encodingID = self.read_ushort()
-            offset = self.read_ulong()
-            save_pos = self._pos
-            if platformID == 3 and encodingID == 10:  # Microsoft, UCS-4
-                format = self.get_ushort(cmap_offset + offset)
-                if (format == 12):
-                    if not unicode_cmap_offset12:
-                        unicode_cmap_offset12 = cmap_offset + offset
-                    break
-            if ((platformID == 3 and encodingID == 1) or platformID == 0):  # Microsoft, Unicode
-                format = self.get_ushort(cmap_offset + offset)
-                if (format == 4):
-                    unicode_cmap_offset = cmap_offset + offset
-                    break
+            #################/
+            # cmap - Character to glyph index mapping table
+            #################/
+            cmap_offset = self.seek_table("cmap")
+            self.skip(2)
+            cmapTableCount = self.read_ushort()
+            unicode_cmap_offset = 0
+            unicode_cmap_offset12 = 0
+            for i in range(cmapTableCount):
+                platformID = self.read_ushort()
+                encodingID = self.read_ushort()
+                offset = self.read_ulong()
+                save_pos = self._pos
+                if platformID == 3 and encodingID == 10:  # Microsoft, UCS-4
+                    format = self.get_ushort(cmap_offset + offset)
+                    if (format == 12):
+                        if not unicode_cmap_offset12:
+                            unicode_cmap_offset12 = cmap_offset + offset
+                        break
+                if ((platformID == 3 and encodingID == 1) or platformID == 0):  # Microsoft, Unicode
+                    format = self.get_ushort(cmap_offset + offset)
+                    if (format == 4):
+                        unicode_cmap_offset = cmap_offset + offset
+                        break
                 
-            self.seek(save_pos )
-        
-        if not unicode_cmap_offset and not unicode_cmap_offset12:
-            die('Font (' + self.filename + ') does not have cmap for Unicode (platform 3, encoding 1, format 4, or platform 3, encoding 10, format 12, or platform 0, any encoding, format 4)')
+                self.seek(save_pos )
+            
+            if not unicode_cmap_offset and not unicode_cmap_offset12:
+                die('Font (' + self.filename + ') does not have cmap for Unicode (platform 3, encoding 1, format 4, or platform 3, encoding 10, format 12, or platform 0, any encoding, format 4)')
 
-        glyphToChar = {}
-        charToGlyph = {}
-        if unicode_cmap_offset12:
-            self.getCMAP12(unicode_cmap_offset12, glyphToChar, charToGlyph)
-        else:    
-            self.getCMAP4(unicode_cmap_offset, glyphToChar, charToGlyph)
+            glyphToChar = {}
+            charToGlyph = {}
+            if unicode_cmap_offset12:
+                self.getCMAP12(unicode_cmap_offset12, glyphToChar, charToGlyph)
+            else:    
+                self.getCMAP4(unicode_cmap_offset, glyphToChar, charToGlyph)
 
-        self.charToGlyph = charToGlyph
+            self.charToGlyph = charToGlyph
 
-        #################/
-        # hmtx - Horizontal metrics table
-        #################/
-        scale = 1    # not used
-        self.getHMTX(numberOfHMetrics, numGlyphs, glyphToChar, scale)
+            #################/
+            # hmtx - Horizontal metrics table
+            #################/
+            scale = 1    # not used
+            self.getHMTX(numberOfHMetrics, numGlyphs, glyphToChar, scale)
 
-        #################/
-        # loca - Index to location
-        #################/
-        self.getLOCA(indexToLocFormat, numGlyphs)
+            #################/
+            # loca - Index to location
+            #################/
+            self.getLOCA(indexToLocFormat, numGlyphs)
 
-        subsetglyphs = [(0, 0)]     # special "sorted dict"!
-        subsetCharToGlyph = {}
-        for code in subset: 
-            if (code in self.charToGlyph):
-                if (self.charToGlyph[code], code) not in subsetglyphs:
-                    subsetglyphs.append((self.charToGlyph[code], code))   # Old Glyph ID => Unicode
-                subsetCharToGlyph[code] = self.charToGlyph[code]    # Unicode to old GlyphID
-            self.maxUni = max(self.maxUni, code)
-        (start,dummy) = self.get_table_pos('glyf')
+            subsetglyphs = [(0, 0)]     # special "sorted dict"!
+            subsetCharToGlyph = {}
+            for code in subset: 
+                if (code in self.charToGlyph):
+                    if (self.charToGlyph[code], code) not in subsetglyphs:
+                        subsetglyphs.append((self.charToGlyph[code], code))   # Old Glyph ID => Unicode
+                    subsetCharToGlyph[code] = self.charToGlyph[code]    # Unicode to old GlyphID
+                self.maxUni = max(self.maxUni, code)
+            (start,dummy) = self.get_table_pos('glyf')
 
-        subsetglyphs.sort()
-        glyphSet = {}
-        n = 0
-        fsLastCharIndex = 0    # maximum Unicode index (character code) in this font, according to the cmap subtable for platform ID 3 and platform- specific encoding ID 0 or 1.
-        for originalGlyphIdx, uni in subsetglyphs:
-            fsLastCharIndex = max(fsLastCharIndex , uni)
-            glyphSet[originalGlyphIdx] = n    # old glyphID to new glyphID
-            n += 1
+            subsetglyphs.sort()
+            glyphSet = {}
+            n = 0
+            fsLastCharIndex = 0    # maximum Unicode index (character code) in this font, according to the cmap subtable for platform ID 3 and platform- specific encoding ID 0 or 1.
+            for originalGlyphIdx, uni in subsetglyphs:
+                fsLastCharIndex = max(fsLastCharIndex , uni)
+                glyphSet[originalGlyphIdx] = n    # old glyphID to new glyphID
+                n += 1
 
-        codeToGlyph = {}
-        for uni, originalGlyphIdx in sorted(subsetCharToGlyph.items()):
-            codeToGlyph[uni] = glyphSet[originalGlyphIdx] 
-        
-        self.codeToGlyph = codeToGlyph
-        
-        for originalGlyphIdx, uni in subsetglyphs: 
-            nonlocals = {'start': start, 'glyphSet': glyphSet, 
-                         'subsetglyphs': subsetglyphs}
-            self.getGlyphs(originalGlyphIdx, nonlocals)
+            codeToGlyph = {}
+            for uni, originalGlyphIdx in sorted(subsetCharToGlyph.items()):
+                codeToGlyph[uni] = glyphSet[originalGlyphIdx] 
+            
+            self.codeToGlyph = codeToGlyph
+            
+            for originalGlyphIdx, uni in subsetglyphs: 
+                nonlocals = {'start': start, 'glyphSet': glyphSet, 
+                             'subsetglyphs': subsetglyphs}
+                self.getGlyphs(originalGlyphIdx, nonlocals)
 
-        numGlyphs = numberOfHMetrics = len(subsetglyphs)
+            numGlyphs = numberOfHMetrics = len(subsetglyphs)
 
-        #tables copied from the original
-        tags = ['name']
-        for tag in tags:  
-            self.add(tag, self.get_table(tag)) 
-        tags = ['cvt ', 'fpgm', 'prep', 'gasp']
-        for tag in tags:
-            if (tag in self.tables):  
-                self.add(tag, self.get_table(tag))        
+            #tables copied from the original
+            tags = ['name']
+            for tag in tags:  
+                self.add(tag, self.get_table(tag)) 
+            tags = ['cvt ', 'fpgm', 'prep', 'gasp']
+            for tag in tags:
+                if (tag in self.tables):  
+                    self.add(tag, self.get_table(tag))        
 
-        # post - PostScript
-        opost = self.get_table('post')
-        post = b("\x00\x03\x00\x00") + substr(opost,4,12) + b("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
-        self.add('post', post)
+            # post - PostScript
+            opost = self.get_table('post')
+            post = b("\x00\x03\x00\x00") + substr(opost,4,12) + b("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+            self.add('post', post)
 
-        # Sort CID2GID map into segments of contiguous codes
-        if 0 in codeToGlyph:
-            del codeToGlyph[0]
-        #unset(codeToGlyph[65535])
-        rangeid = 0
-        range_ = {}
-        prevcid = -2
-        prevglidx = -1
-        # for each character
-        for cid, glidx in sorted(codeToGlyph.items()):
-            if (cid == (prevcid + 1) and glidx == (prevglidx + 1)):
-                range_[rangeid].append(glidx)
-            else:
-                # new range
-                rangeid = cid
-                range_[rangeid] = []
-                range_[rangeid].append(glidx)
-            prevcid = cid
-            prevglidx = glidx
+            # Sort CID2GID map into segments of contiguous codes
+            if 0 in codeToGlyph:
+                del codeToGlyph[0]
+            #unset(codeToGlyph[65535])
+            rangeid = 0
+            range_ = {}
+            prevcid = -2
+            prevglidx = -1
+            # for each character
+            for cid, glidx in sorted(codeToGlyph.items()):
+                if (cid == (prevcid + 1) and glidx == (prevglidx + 1)):
+                    range_[rangeid].append(glidx)
+                else:
+                    # new range
+                    rangeid = cid
+                    range_[rangeid] = []
+                    range_[rangeid].append(glidx)
+                prevcid = cid
+                prevglidx = glidx
 
-        # cmap - Character to glyph mapping - Format 4 (MS / )
-        segCount = len(range_) + 1    # + 1 Last segment has missing character 0xFFFF
-        searchRange = 1
-        entrySelector = 0
-        while (searchRange * 2 <= segCount ):
+            # cmap - Character to glyph mapping - Format 4 (MS / )
+            segCount = len(range_) + 1    # + 1 Last segment has missing character 0xFFFF
+            searchRange = 1
+            entrySelector = 0
+            while (searchRange * 2 <= segCount ):
+                searchRange = searchRange * 2
+                entrySelector = entrySelector + 1
+            
             searchRange = searchRange * 2
-            entrySelector = entrySelector + 1
-        
-        searchRange = searchRange * 2
-        rangeShift = segCount * 2 - searchRange
-        length = 16 + (8*segCount ) + (numGlyphs+1)
-        cmap = [0, 1,        # Index : version, number of encoding subtables
-            3, 1,                # Encoding Subtable : platform (MS=3), encoding (Unicode)
-            0, 12,            # Encoding Subtable : offset (hi,lo)
-            4, length, 0,         # Format 4 Mapping subtable: format, length, language
-            segCount*2,
-            searchRange,
-            entrySelector,
-            rangeShift]
+            rangeShift = segCount * 2 - searchRange
+            length = 16 + (8*segCount ) + (numGlyphs+1)
+            cmap = [0, 1,        # Index : version, number of encoding subtables
+                3, 1,                # Encoding Subtable : platform (MS=3), encoding (Unicode)
+                0, 12,            # Encoding Subtable : offset (hi,lo)
+                4, length, 0,         # Format 4 Mapping subtable: format, length, language
+                segCount*2,
+                searchRange,
+                entrySelector,
+                rangeShift]
 
-        range_ = sorted(range_.items())
-        
-        # endCode(s)
-        for start, subrange in range_:
-            endCode = start + (len(subrange)-1)
-            cmap.append(endCode)    # endCode(s)
-        
-        cmap.append(0xFFFF)    # endCode of last Segment
-        cmap.append(0)    # reservedPad
+            range_ = sorted(range_.items())
+            
+            # endCode(s)
+            for start, subrange in range_:
+                endCode = start + (len(subrange)-1)
+                cmap.append(endCode)    # endCode(s)
+            
+            cmap.append(0xFFFF)    # endCode of last Segment
+            cmap.append(0)    # reservedPad
 
-        # startCode(s)
-        for start, subrange in range_: 
-            cmap.append(start)    # startCode(s)
-        
-        cmap.append(0xFFFF)    # startCode of last Segment
-        # idDelta(s) 
-        for start, subrange in range_: 
-            idDelta = -(start-subrange[0])
-            n += count(subrange)
-            cmap.append(idDelta)    # idDelta(s)
-        
-        cmap.append(1)    # idDelta of last Segment
-        # idRangeOffset(s) 
-        for subrange in range_: 
-            cmap.append(0)    # idRangeOffset[segCount]      Offset in bytes to glyph indexArray, or 0
-        
-        cmap.append(0)    # idRangeOffset of last Segment
-        for subrange, glidx in range_: 
-            cmap.extend(glidx)
-        
-        cmap.append(0)    # Mapping for last character
-        cmapstr = b('')
-        for cm in cmap:
-            if cm >= 0:
-                cmapstr += pack(">H", cm) 
-            else:
+            # startCode(s)
+            for start, subrange in range_: 
+                cmap.append(start)    # startCode(s)
+            
+            cmap.append(0xFFFF)    # startCode of last Segment
+            # idDelta(s) 
+            for start, subrange in range_: 
+                idDelta = -(start-subrange[0])
+                n += count(subrange)
+                cmap.append(idDelta)    # idDelta(s)
+            
+            cmap.append(1)    # idDelta of last Segment
+            # idRangeOffset(s) 
+            for subrange in range_: 
+                cmap.append(0)    # idRangeOffset[segCount]      Offset in bytes to glyph indexArray, or 0
+            
+            cmap.append(0)    # idRangeOffset of last Segment
+            for subrange, glidx in range_: 
+                cmap.extend(glidx)
+            
+            cmap.append(0)    # Mapping for last character
+            cmapstr = b('')
+            for cm in cmap:
+                if cm >= 0:
+                    cmapstr += pack(">H", cm) 
+                else:
+                    try:
+                        cmapstr += pack(">h", cm) 
+                    except:
+                        warnings.warn("cmap value too big/small: %s" % cm)
+                        cmapstr += pack(">H", -cm) 
+            self.add('cmap', cmapstr)
+
+            # glyf - Glyph data
+            (glyfOffset,glyfLength) = self.get_table_pos('glyf')
+            if (glyfLength < self.maxStrLenRead):
+                glyphData = self.get_table('glyf')
+
+            offsets = []
+            glyf = b('')
+            pos = 0
+
+            hmtxstr = b('')
+            xMinT = 0
+            yMinT = 0
+            xMaxT = 0
+            yMaxT = 0
+            advanceWidthMax = 0
+            minLeftSideBearing = 0
+            minRightSideBearing = 0
+            xMaxExtent = 0
+            maxPoints = 0            # points in non-compound glyph
+            maxContours = 0            # contours in non-compound glyph
+            maxComponentPoints = 0    # points in compound glyph
+            maxComponentContours = 0    # contours in compound glyph
+            maxComponentElements = 0    # number of glyphs referenced at top level
+            maxComponentDepth = 0        # levels of recursion, set to 0 if font has only simple glyphs
+            self.glyphdata = {}
+
+            for originalGlyphIdx, uni in subsetglyphs: 
+                # hmtx - Horizontal Metrics
+                hm = self.getHMetric(orignHmetrics, originalGlyphIdx)    
+                hmtxstr += hm
+
+                offsets.append(pos)
                 try:
-                    cmapstr += pack(">h", cm) 
-                except:
-                    warnings.warn("cmap value too big/small: %s" % cm)
-                    cmapstr += pack(">H", -cm) 
-        self.add('cmap', cmapstr)
+                    glyphPos = self.glyphPos[originalGlyphIdx]
+                    glyphLen = self.glyphPos[originalGlyphIdx + 1] - glyphPos
+                except IndexError:
+                    warnings.warn("missing glyph %s" % (originalGlyphIdx))
+                    glyphLen = 0
 
-        # glyf - Glyph data
-        (glyfOffset,glyfLength) = self.get_table_pos('glyf')
-        if (glyfLength < self.maxStrLenRead):
-            glyphData = self.get_table('glyf')
-
-        offsets = []
-        glyf = b('')
-        pos = 0
-
-        hmtxstr = b('')
-        xMinT = 0
-        yMinT = 0
-        xMaxT = 0
-        yMaxT = 0
-        advanceWidthMax = 0
-        minLeftSideBearing = 0
-        minRightSideBearing = 0
-        xMaxExtent = 0
-        maxPoints = 0            # points in non-compound glyph
-        maxContours = 0            # contours in non-compound glyph
-        maxComponentPoints = 0    # points in compound glyph
-        maxComponentContours = 0    # contours in compound glyph
-        maxComponentElements = 0    # number of glyphs referenced at top level
-        maxComponentDepth = 0        # levels of recursion, set to 0 if font has only simple glyphs
-        self.glyphdata = {}
-
-        for originalGlyphIdx, uni in subsetglyphs: 
-            # hmtx - Horizontal Metrics
-            hm = self.getHMetric(orignHmetrics, originalGlyphIdx)    
-            hmtxstr += hm
+                if (glyfLength < self.maxStrLenRead):
+                    data = substr(glyphData,glyphPos,glyphLen)
+                else:
+                    if (glyphLen > 0):
+                        data = self.get_chunk(glyfOffset+glyphPos,glyphLen)
+                    else:
+                        data = b('')
+                
+                if (glyphLen > 0):
+                    up = unpack(">H", substr(data,0,2))[0]
+                if (glyphLen > 2 and (up & (1 << 15)) ):     # If number of contours <= -1 i.e. composite glyph
+                    pos_in_glyph = 10
+                    flags = GF_MORE
+                    nComponentElements = 0
+                    while (flags & GF_MORE):
+                        nComponentElements += 1    # number of glyphs referenced at top level
+                        up = unpack(">H", substr(data,pos_in_glyph,2))
+                        flags = up[0]
+                        up = unpack(">H", substr(data,pos_in_glyph+2,2))
+                        glyphIdx = up[0]
+                        self.glyphdata.setdefault(originalGlyphIdx, {}).setdefault('compGlyphs', []).append(glyphIdx)
+                        try:
+                            data = self._set_ushort(data, pos_in_glyph + 2, glyphSet[glyphIdx])
+                        except KeyError:
+                            data = 0
+                            warnings.warn("missing glyph data %s" % glyphIdx)
+                        pos_in_glyph += 4
+                        if (flags & GF_WORDS): 
+                            pos_in_glyph += 4 
+                        else: 
+                            pos_in_glyph += 2 
+                        if (flags & GF_SCALE):
+                            pos_in_glyph += 2 
+                        elif (flags & GF_XYSCALE):
+                            pos_in_glyph += 4 
+                        elif (flags & GF_TWOBYTWO):
+                            pos_in_glyph += 8 
+                    
+                    maxComponentElements = max(maxComponentElements, nComponentElements)
+                
+                glyf += data
+                pos += glyphLen
+                if (pos % 4 != 0): 
+                    padding = 4 - (pos % 4)
+                    glyf += str_repeat(b("\0"),padding)
+                    pos += padding
 
             offsets.append(pos)
-            try:
-                glyphPos = self.glyphPos[originalGlyphIdx]
-                glyphLen = self.glyphPos[originalGlyphIdx + 1] - glyphPos
-            except IndexError:
-                warnings.warn("missing glyph %s" % (originalGlyphIdx))
-                glyphLen = 0
+            self.add('glyf', glyf)
 
-            if (glyfLength < self.maxStrLenRead):
-                data = substr(glyphData,glyphPos,glyphLen)
+            # hmtx - Horizontal Metrics
+            self.add('hmtx', hmtxstr)
+
+            # loca - Index to location
+            locastr = b('')
+            if (((pos + 1) >> 1) > 0xFFFF): 
+                indexToLocFormat = 1        # long format
+                for offset in offsets:
+                    locastr += pack(">L",offset) 
             else:
-                if (glyphLen > 0):
-                    data = self.get_chunk(glyfOffset+glyphPos,glyphLen)
-                else:
-                    data = b('')
+                indexToLocFormat = 0        # short format
+                for offset in offsets:  
+                    locastr += pack(">H",int(offset/2)) 
             
-            if (glyphLen > 0):
-                up = unpack(">H", substr(data,0,2))[0]
-            if (glyphLen > 2 and (up & (1 << 15)) ):     # If number of contours <= -1 i.e. composite glyph
-                pos_in_glyph = 10
-                flags = GF_MORE
-                nComponentElements = 0
-                while (flags & GF_MORE):
-                    nComponentElements += 1    # number of glyphs referenced at top level
-                    up = unpack(">H", substr(data,pos_in_glyph,2))
-                    flags = up[0]
-                    up = unpack(">H", substr(data,pos_in_glyph+2,2))
-                    glyphIdx = up[0]
-                    self.glyphdata.setdefault(originalGlyphIdx, {}).setdefault('compGlyphs', []).append(glyphIdx)
-                    try:
-                        data = self._set_ushort(data, pos_in_glyph + 2, glyphSet[glyphIdx])
-                    except KeyError:
-                        data = 0
-                        warnings.warn("missing glyph data %s" % glyphIdx)
-                    pos_in_glyph += 4
-                    if (flags & GF_WORDS): 
-                        pos_in_glyph += 4 
-                    else: 
-                        pos_in_glyph += 2 
-                    if (flags & GF_SCALE):
-                        pos_in_glyph += 2 
-                    elif (flags & GF_XYSCALE):
-                        pos_in_glyph += 4 
-                    elif (flags & GF_TWOBYTWO):
-                        pos_in_glyph += 8 
-                
-                maxComponentElements = max(maxComponentElements, nComponentElements)
-            
-            glyf += data
-            pos += glyphLen
-            if (pos % 4 != 0): 
-                padding = 4 - (pos % 4)
-                glyf += str_repeat(b("\0"),padding)
-                pos += padding
+            self.add('loca', locastr)
 
-        offsets.append(pos)
-        self.add('glyf', glyf)
+            # head - Font header
+            head = self.get_table('head')
+            head = self._set_ushort(head, 50, indexToLocFormat)
+            self.add('head', head)
 
-        # hmtx - Horizontal Metrics
-        self.add('hmtx', hmtxstr)
+            # hhea - Horizontal Header
+            hhea = self.get_table('hhea')
+            hhea = self._set_ushort(hhea, 34, numberOfHMetrics)
+            self.add('hhea', hhea)
 
-        # loca - Index to location
-        locastr = b('')
-        if (((pos + 1) >> 1) > 0xFFFF): 
-            indexToLocFormat = 1        # long format
-            for offset in offsets:
-                locastr += pack(">L",offset) 
-        else:
-            indexToLocFormat = 0        # short format
-            for offset in offsets:  
-                locastr += pack(">H",int(offset/2)) 
-        
-        self.add('loca', locastr)
+            # maxp - Maximum Profile
+            maxp = self.get_table('maxp')
+            maxp = self._set_ushort(maxp, 4, numGlyphs)
+            self.add('maxp', maxp)
 
-        # head - Font header
-        head = self.get_table('head')
-        head = self._set_ushort(head, 50, indexToLocFormat)
-        self.add('head', head)
-
-        # hhea - Horizontal Header
-        hhea = self.get_table('hhea')
-        hhea = self._set_ushort(hhea, 34, numberOfHMetrics)
-        self.add('hhea', hhea)
-
-        # maxp - Maximum Profile
-        maxp = self.get_table('maxp')
-        maxp = self._set_ushort(maxp, 4, numGlyphs)
-        self.add('maxp', maxp)
-
-        # OS/2 - OS/2
-        os2 = self.get_table('OS/2')
-        self.add('OS/2', os2 )
-
-        self.fh.close()
+            # OS/2 - OS/2
+            os2 = self.get_table('OS/2')
+            self.add('OS/2', os2 )
 
         # Put the TTF file together
         stm = self.endTTFile('')

--- a/fpdf/ttfonts.py
+++ b/fpdf/ttfonts.py
@@ -93,7 +93,7 @@ class TTFontFile:
             if (version==0x74746366):
                 die("ERROR - TrueType Fonts Collections not supported")
             if (version not in (0x00010000,0x74727565)):
-                die("Not a TrueType font: version=" + version)
+                die("Not a TrueType font: version=" + str(version))
             self.readTableDirectory()
             self.extractInfo()
     

--- a/fpdf/ttfonts.py
+++ b/fpdf/ttfonts.py
@@ -244,7 +244,7 @@ class TTFontFile:
                 self.seek(string_data_offset + offset)
                 if (length % 2 != 0):
                     die("PostScript name is UTF-16BE string of odd length")
-                length /= 2
+                length //= 2
                 N = ''
                 while (length > 0):
                     char = self.read_ushort()
@@ -773,7 +773,7 @@ class TTFontFile:
             else:
                 indexToLocFormat = 0        # short format
                 for offset in offsets:  
-                    locastr += pack(">H",int(offset/2)) 
+                    locastr += pack(">H",offset//2) 
             
             self.add('loca', locastr)
 
@@ -873,7 +873,7 @@ class TTFontFile:
         nCharWidths = 0
         if ((numberOfHMetrics*4) < self.maxStrLenRead): 
             data = self.get_chunk(start,(numberOfHMetrics*4))
-            arr = unpack(">%dH" % (int(len(data)/2)), data)
+            arr = unpack(">%dH" % (len(data)//2), data)
         else:
             self.seek(start) 
         for glyph in range(numberOfHMetrics): 
@@ -903,7 +903,7 @@ class TTFontFile:
             
         
         data = self.get_chunk((start+numberOfHMetrics*4),(numGlyphs*2))
-        arr = unpack(">%dH" % (int(len(data)/2)), data)
+        arr = unpack(">%dH" % (len(data)//2), data)
         diff = numGlyphs-numberOfHMetrics
         for pos in range(diff): 
             glyph = pos + numberOfHMetrics
@@ -942,12 +942,12 @@ class TTFontFile:
         self.glyphPos = []
         if (indexToLocFormat == 0):
             data = self.get_chunk(start,(numGlyphs*2)+2)
-            arr = unpack(">%dH" % (int(len(data)/2)), data)
+            arr = unpack(">%dH" % (len(data)//2), data)
             for n in range(numGlyphs): 
                 self.glyphPos.append((arr[n] * 2))  # n+1 !?
         elif (indexToLocFormat == 1):
             data = self.get_chunk(start,(numGlyphs*4)+4)
-            arr = unpack(">%dL" % (int(len(data)/4)), data)
+            arr = unpack(">%dL" % (len(data)//4), data)
             for n in range(numGlyphs):
                 self.glyphPos.append((arr[n]))  # n+1 !?
         else:
@@ -961,7 +961,7 @@ class TTFontFile:
         limit = unicode_cmap_offset + length
         self.skip(2)
 
-        segCount = int(self.read_ushort() / 2)
+        segCount = self.read_ushort() // 2
         self.skip(6)
         endCount = []
         for i in range(segCount):

--- a/tests/charmap.py
+++ b/tests/charmap.py
@@ -36,7 +36,7 @@ pdf.set_font("font", '', 10)
 cnt = 0
 for char in ttf.saveChar:
     cnt += 1
-    pdf.write(8, u"%03d) %06x - " % (cnt, char) + unichr(char))
+    pdf.write(8, u"%03d) %06x - %c" % (cnt, char, char))
     pdf.ln()
     if cnt >= 999:
         break

--- a/tests/cover/common.py
+++ b/tests/cover/common.py
@@ -5,6 +5,8 @@
 #       2) import this file before import fpdf
 #       3) assert this file in tests/cover folder
 
+from __future__ import with_statement
+
 import sys, os, subprocess
 import unittest, inspect
 
@@ -95,21 +97,17 @@ def test_putinfo(self):
 def file_hash(fn):
     "Calc MD5 hash for file"
     md = md5()
-    f = open(fn, "rb")
-    try:
+    with open(fn, "rb") as f:
         md.update(f.read())
-    finally:
-        f.close()
     return md.hexdigest()
 
 def read_cover_info(fn):
     "Read cover test info"
-    f = open(fn, "rb")
-    da = {"res": []}
-    mark = "#PyFPDF-cover-test:"
-    encmark = "# -*- coding:"
-    enc = None
-    try:
+    with open(fn, "rb") as f:
+        da = {"res": []}
+        mark = "#PyFPDF-cover-test:"
+        encmark = "# -*- coding:"
+        enc = None
         hdr = False
         for line in f.readlines():
             if enc is None:
@@ -133,9 +131,6 @@ def read_cover_info(fn):
             else:
                 if hdr and len(line) == 0:
                     break
-                
-    finally:
-        f.close()
     return da
 
 def parse_test_args(args, deffn):
@@ -165,23 +160,24 @@ def parse_test_args(args, deffn):
 def load_res_file(path):
     items = {}
     res = None
-    for line in open(path):
-        line = line.strip()
-        if line[:1] == "#":
-            continue
-        kv = line.split("=", 1)
-        if len(kv) != 2:
-            continue
-        if kv[0] == "res":
-            res = kv[1]
-            if res not in items:
-                items[res] = ["", []]
-        elif res is None:
-            continue
-        elif kv[0] == "hash":
-            items[res][0] = kv[1]
-        elif kv[0] == "tags":
-            items[res][1] += [kv[1].split(",")]
+    with open(path) as file:
+        for line in file:
+            line = line.strip()
+            if line[:1] == "#":
+                continue
+            kv = line.split("=", 1)
+            if len(kv) != 2:
+                continue
+            if kv[0] == "res":
+                res = kv[1]
+                if res not in items:
+                    items[res] = ["", []]
+            elif res is None:
+                continue
+            elif kv[0] == "hash":
+                items[res][0] = kv[1]
+            elif kv[0] == "tags":
+                items[res][1] += [kv[1].split(",")]
     return items
     
 def skip_reason(settings):

--- a/tests/cover/test_cache.py
+++ b/tests/cover/test_cache.py
@@ -2,6 +2,8 @@
 
 "Test caching"
 
+from __future__ import with_statement
+
 #PyFPDF-cover-test:res=font/DejaVuSansCondensed.ttf
 #PyFPDF-cover-test:res=font/DejaVuSans.ttf
 
@@ -21,9 +23,8 @@ def testfile(f1, f2):
     return pdf
 
 def trashfile(fn):
-    f = open(fn, "w")
-    f.write("1234567890")
-    f.close()
+    with open(fn, "w") as f:
+        f.write("1234567890")
 
 try:
     from hashlib import md5

--- a/tests/cover/test_invoice.py
+++ b/tests/cover/test_invoice.py
@@ -102,7 +102,7 @@ def dotest(outputname, nostamp):
     # calculate pages:
     lines = len(li_items)
     max_lines_per_page = 24
-    pages = int(lines / (max_lines_per_page - 1))
+    pages = lines // (max_lines_per_page - 1)
     if lines % (max_lines_per_page - 1): pages = pages + 1
 
     # completo campos y hojas

--- a/tests/cover/test_issue33.py
+++ b/tests/cover/test_issue33.py
@@ -2,6 +2,8 @@
 
 "Test issue 33 (Cannot import GIF files that don't have transparency)"
 
+from __future__ import with_statement
+
 #PyFPDF-cover-test:format=PDF
 #PyFPDF-cover-test:fn=issue_33.pdf
 #PyFPDF-cover-test:hash=be95c7ef3a5b14b5a54a52f7eaf3a9e4
@@ -66,12 +68,10 @@ def dotest(outputname, nostamp):
     img = Image.fromstring("P", plane.size, plane.tostring())
     img.putpalette(palette)
 
-    f = tempfile.NamedTemporaryFile(delete = False, suffix = ".gif")
-    gif1 = f.name
-    f.close()
-    f = tempfile.NamedTemporaryFile(delete = False, suffix = ".gif")
-    gif2 = f.name
-    f.close()
+    with tempfile.NamedTemporaryFile(delete = False, suffix = ".gif") as f:
+        gif1 = f.name
+    with tempfile.NamedTemporaryFile(delete = False, suffix = ".gif") as f:
+        gif2 = f.name
 
     img.save(gif1, "GIF", optimize = 0)
     img.save(gif2, "GIF", transparency = 1, optimize = 0)

--- a/tests/cover/test_issue41.py
+++ b/tests/cover/test_issue41.py
@@ -2,6 +2,8 @@
 
 "Test issue 41 (escape CR char)"
 
+from __future__ import with_statement
+
 #PyFPDF-cover-test:format=TXT
 #PyFPDF-cover-test:fn=issue_41.txt
 #PyFPDF-cover-test:hash=c576afec3362a7cc3b4b07a12feeefd3
@@ -20,9 +22,8 @@ def dotest(outputname, nostamp):
         "| [ ] ABCDEF..XYZ 56789\n"
          
     pdf = fpdf.FPDF()
-    f = open(outputname, "wb")
-    f.write(pdf._escape(txt).encode("latin1"))
-    f.close()
+    with open(outputname, "wb") as f:
+        f.write(pdf._escape(txt).encode("latin1"))
 
 def main():
     return common.testmain(__file__, dotest)

--- a/tests/cover/test_issue82.py
+++ b/tests/cover/test_issue82.py
@@ -22,8 +22,8 @@ def dotest(outputname, nostamp):
         uni = True)
     pdf.set_font('DejaVu','',14)
 
-    txt = open(os.path.join(common.basepath, "HelloWorld.txt"), "rb").\
-        read().decode("UTF-8")
+    with open(os.path.join(common.basepath, "HelloWorld.txt"), "rb") as file:
+        txt = file.read().decode("UTF-8")
     std_ln = [27.0849, 37.9455, 30.4927, 25.7711, 41.0175, 38.7406, 30.3445, 
         22.1163, 34.8314, 12.0813, 20.0829, 14.7485, 33.4188]
     for line, reqw in zip(txt.split("\n"), std_ln):

--- a/tests/cover/test_stretching.py
+++ b/tests/cover/test_stretching.py
@@ -54,8 +54,8 @@ def dotest(outputname, nostamp):
         os.path.join(common.basepath, "font", 'DejaVuSans.ttf'), \
         uni = True)
     pdf.set_font('DejaVu', '', 14)
-    txt = open(os.path.join(common.basepath, "HelloWorld.txt"), "rb").\
-        read().decode("UTF-8")
+    with open(os.path.join(common.basepath, "HelloWorld.txt"), "rb") as file:
+        txt = file.read().decode("UTF-8")
 
     if not nostamp:
         text(pdf, txt, 100, nostamp)

--- a/tests/cover/test_ttfonts.py
+++ b/tests/cover/test_ttfonts.py
@@ -34,7 +34,7 @@ def dotest(outputname, nostamp):
     with open(os.path.join(common.basepath, "dejavusanscondensed.cw.dat"),\
             "rb") as file:
         data = file.read()
-    char_widths = struct.unpack(">%dH" % int(len(data) / 2), data)
+    char_widths = struct.unpack(">%dH" % (len(data) // 2), data)
     assert len(char_widths) == 65536, "Check cw.dat char_widths 65536"
     assert len(ttf.charWidths) == 65536, "Check ttf char_widths 65536"
     diff = []

--- a/tests/cover/test_ttfonts.py
+++ b/tests/cover/test_ttfonts.py
@@ -2,6 +2,8 @@
 
 "Basic test of TrueType Unicode font handling"
 
+from __future__ import with_statement
+
 #PyFPDF-cover-test:res=font/DejaVuSansCondensed.ttf
 #PyFPDF-cover-test:res=dejavusanscondensed.cw.dat
 
@@ -29,8 +31,9 @@ def dotest(outputname, nostamp):
     # note: after fixing issue 82 this raw data started to be wrong
     #  1. total length - 65536, DejaVuSansCondensed.ttf maximal char is 65533, round to nearest 1024 size
     #  2. missing char width should be 540 instead of zero
-    data = open(os.path.join(common.basepath, "dejavusanscondensed.cw.dat"),\
-        "rb").read()
+    with open(os.path.join(common.basepath, "dejavusanscondensed.cw.dat"),\
+            "rb") as file:
+        data = file.read()
     char_widths = struct.unpack(">%dH" % int(len(data) / 2), data)
     assert len(char_widths) == 65536, "Check cw.dat char_widths 65536"
     assert len(ttf.charWidths) == 65536, "Check ttf char_widths 65536"

--- a/tests/cover/test_unicode.py
+++ b/tests/cover/test_unicode.py
@@ -2,6 +2,8 @@
 
 "Example of unicode support based on tfPDF http://www.fpdf.org/en/script/script92.php"
 
+from __future__ import with_statement
+
 #PyFPDF-cover-test:format=PDF
 #PyFPDF-cover-test:fn=ex.pdf
 #PyFPDF-cover-test:hash=e3c74fe7738fba7eed0cd489c597dc88
@@ -27,8 +29,8 @@ def dotest(outputname, nostamp):
     pdf.set_font('DejaVu','',14)
 
     # Load a UTF-8 string from a file and print it
-    txt = open(os.path.join(common.basepath, "HelloWorld.txt"), "rb").\
-        read().decode("UTF-8")
+    with open(os.path.join(common.basepath, "HelloWorld.txt"), "rb") as file:
+        txt = file.read().decode("UTF-8")
     pdf.write(8, txt)
 
 

--- a/tests/cover/test_winfonts.py
+++ b/tests/cover/test_winfonts.py
@@ -3,6 +3,8 @@
 "Example of unicode support winfonts based on tfPDF"
 # http://www.fpdf.org/en/script/script92.php
 
+from __future__ import with_statement
+
 #PyFPDF-cover-test:format=PDF
 #PyFPDF-cover-test:fn=winfonts.pdf
 #PyFPDF-cover-test:platform=win32
@@ -33,8 +35,8 @@ def dotest(outputname, nostamp):
         common.log("ttf loading time", t1-t0)
 
     # Load a UTF-8 string from a file and print it
-    txt = open(os.path.join(common.basepath, "HelloWorld.txt"), "rb").\
-        read().decode("UTF-8")
+    with open(os.path.join(common.basepath, "HelloWorld.txt"), "rb") as file:
+        txt = file.read().decode("UTF-8")
     pdf.multi_cell(25, 5, txt)
 
     pdf.text(100, 5, '1234')

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -56,7 +56,7 @@ def search_python_win():
                     ver = winreg.EnumKey(rl, i)
                     rv = winreg.QueryValue(key, PATH + "\\" + ver + "\\InstallPath")
                     fp = os.path.join(rv, "python.exe")
-                    #print fp
+                    #print(fp)
                     if os.path.exists(fp) and not fp in lst:
                         lst.append(fp)
             except WindowsError:

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import with_statement
 
 import os, sys
 import cover
@@ -164,14 +165,13 @@ def do_test_one(testfile, interp, info, dest):
         shutil.copy(testfile, destpath)
     # start execution
     std, err = cover.exec_cmd([path, "-B", newfile, "--check", "--auto", newres])
-    f = open(os.path.join(destpath, "testlog.txt"), "a")
-    f.write("#" * 40 + "\n")
-    f.write(testname + "\n")
-    f.write("=" * 40 + "\n")
-    f.write(std)
-    f.write("-" * 40 + "\n")
-    f.write(err)
-    f.close()
+    with open(os.path.join(destpath, "testlog.txt"), "a") as f:
+        f.write("#" * 40 + "\n")
+        f.write(testname + "\n")
+        f.write("=" * 40 + "\n")
+        f.write(std)
+        f.write("-" * 40 + "\n")
+        f.write(err)
 
     answ = std.strip()
     if answ.find("\n") >= 0 or len(answ) == 0:
@@ -196,33 +196,32 @@ def prepare_dest(interp):
     src = os.path.join(cover.basepath, "cover")
     shutil.copy(os.path.join(src, "common.py"), destpath)
     shutil.copy(os.path.join(src, "checkenv.py"), destpath)
-    f = open(os.path.join(destpath, "testlog.txt"), "w")
-    f.write("Version: " + interp[1] + "\n")
-    f.write("Path: " + interp[0] + "\n")
-    f.write(str(interp[2:]) + "\n")
+    with open(os.path.join(destpath, "testlog.txt"), "w") as f:
+        f.write("Version: " + interp[1] + "\n")
+        f.write("Path: " + interp[0] + "\n")
+        f.write(str(interp[2:]) + "\n")
 
-    # run checkenv
-    std, err = cover.exec_cmd([interp[0], "-B", os.path.join(destpath, "checkenv.py")])
-    env = {}
-    if len(err.strip()) == 0:
-        # OK
-        f.write("Check environment - ok:\n")
-        f.write(std)
-        lineno = 0
-        for line in std.split("\n"):
-            lineno += 1
-            line = line.strip()
-            if lineno == 1:
-                if line != "CHECK":
-                    break
-            line = line.strip()
-            kv = line.split("=", 1)
-            if len(kv) == 2:
-                env[kv[0].lower().strip()] = kv[1].strip()
-    else:
-        f.write("ERROR:\n")
-        f.write(err)
-    f.close()
+        # run checkenv
+        std, err = cover.exec_cmd([interp[0], "-B", os.path.join(destpath, "checkenv.py")])
+        env = {}
+        if len(err.strip()) == 0:
+            # OK
+            f.write("Check environment - ok:\n")
+            f.write(std)
+            lineno = 0
+            for line in std.split("\n"):
+                lineno += 1
+                line = line.strip()
+                if lineno == 1:
+                    if line != "CHECK":
+                        break
+                line = line.strip()
+                kv = line.split("=", 1)
+                if len(kv) == 2:
+                    env[kv[0].lower().strip()] = kv[1].strip()
+        else:
+            f.write("ERROR:\n")
+            f.write(err)
     return (destpath, env)
 
 def do_test(testfile, interps, dests, stats, hint = ""):
@@ -349,11 +348,8 @@ def hint_prepare():
 
 
 def read_list(fn):
-    f = open(fn, "r")
-    try:
+    with open(fn, "r") as f:
         return f.readlines()
-    finally:
-        f.close()
 
 def hasher(path, args):
     tags = []
@@ -402,30 +398,28 @@ def download_fonts():
         meta = u.info()
         file_size = int(meta.get("Content-Length"))
         cover.log("Downloading:", file_size, "bytes")
-        f = open(zippath, "wb")
-        file_size_dl = 0
-        while True:
-            buff = u.read(64 * 1024)
-            if not buff:
-                break
-            file_size_dl += len(buff)
-            f.write(buff)
-            cover.log("  ", file_size_dl * 100. / file_size, "%")
-        f.close()
+        with open(zippath, "wb") as f:
+            file_size_dl = 0
+            while True:
+                buff = u.read(64 * 1024)
+                if not buff:
+                    break
+                file_size_dl += len(buff)
+                f.write(buff)
+                cover.log("  ", file_size_dl * 100. / file_size, "%")
     # unpack
     cover.log("Extracting")
     import zipfile
-    fh = open(zippath, "rb")
-    z = zipfile.ZipFile(fh)
-    for name in z.namelist():
-        if name[:5] != "font/":
-            continue
-        if name[5:].find("/") >= 0:
-            continue
-        cover.log("  ", name[5:])
-        outfile = open(os.path.join(fntdir, name[5:]), "wb")
-        outfile.write(z.read(name))
-        outfile.close()
+    with open(zippath, "rb") as fh:
+        z = zipfile.ZipFile(fh)
+        for name in z.namelist():
+            if name[:5] != "font/":
+                continue
+            if name[5:].find("/") >= 0:
+                continue
+            cover.log("  ", name[5:])
+            with open(os.path.join(fntdir, name[5:]), "wb") as outfile:
+                outfile.write(z.read(name))
     cover.log("Done")
 
 def main():

--- a/tests/unifonts.py
+++ b/tests/unifonts.py
@@ -1,5 +1,7 @@
 # try all ttf fonts 
 
+from __future__ import with_statement
+
 from fpdf import FPDF
 import fpdf
 import sys
@@ -14,7 +16,8 @@ pdf.add_page()
 #font_dir = fpdf.FPDF_FONT_DIR
 font_dir = os.path.join(base, 'font')
 
-txt = open(os.path.join(base, 'HelloWorld.txt')).read()
+with open(os.path.join(base, 'HelloWorld.txt')) as file:
+    txt = file.read()
 
 # Add a Unicode font (uses UTF-8)
 for font in os.listdir(font_dir):

--- a/tests/unzlib.py
+++ b/tests/unzlib.py
@@ -1,3 +1,5 @@
+from __future__ import with_statement
+
 import zlib
 import sys
 import pdb
@@ -6,36 +8,34 @@ from binascii import hexlify
 
 print(sys.argv[1])
 hex = '--hex' in sys.argv
-r = open(sys.argv[1], 'rb')
-i = 0
-length = None
-while True:
-    l = r.readline().decode("ascii", "replace")  # Avoid byte strings in 2.5
-    if not l:
-        break
-    if "/Length " in l:
-        print(l)
-        s = l[l.index("/Length ")+8:]
-        if ' ' in s:
-            s = s[:s.index(" ")]
-        if '>' in s:
-            s = s[:s.index(">")]
-        length = int(s)
-        print("%s%s" % (l, length))
-    if l.startswith('stream') and length:
-        i += 1
-        fn = "stream_%s_%s" % (i, sys.argv[1])
-        print("writing  %s %s" % (length, fn))
-        s = r.read(length)
-        w = open(fn, 'wb')
-        try:
-            s = zlib.decompress(s)
-        except zlib.error:
-            pass
-        if hex:
-            s = hexlify(s)
-        w.write(s)
-        w.close()
-r.close()
+with open(sys.argv[1], 'rb') as r:
+    i = 0
+    length = None
+    while True:
+        l = r.readline().decode("ascii", "replace")  # Avoid b". . ." in 2.5
+        if not l:
+            break
+        if "/Length " in l:
+            print(l)
+            s = l[l.index("/Length ")+8:]
+            if ' ' in s:
+                s = s[:s.index(" ")]
+            if '>' in s:
+                s = s[:s.index(">")]
+            length = int(s)
+            print("%s%s" % (l, length))
+        if l.startswith('stream') and length:
+            i += 1
+            fn = "stream_%s_%s" % (i, sys.argv[1])
+            print("writing  %s %s" % (length, fn))
+            s = r.read(length)
+            with open(fn, 'wb') as w:
+                try:
+                    s = zlib.decompress(s)
+                except zlib.error:
+                    pass
+                if hex:
+                    s = hexlify(s)
+                w.write(s)
 
 os.system("windiff stream_1_ex_php.pdf stream_1_ex.pdf")

--- a/tests/unzlib.py
+++ b/tests/unzlib.py
@@ -2,29 +2,30 @@ import zlib
 import sys
 import pdb
 import os
+from binascii import hexlify
 
-print sys.argv[1]
+print(sys.argv[1])
 hex = '--hex' in sys.argv
 r = open(sys.argv[1], 'rb')
 i = 0
 length = None
 while True:
-    l = r.readline()
-    if l == "":
+    l = r.readline().decode("ascii", "replace")  # Avoid byte strings in 2.5
+    if not l:
         break
     if "/Length " in l:
-        print l
+        print(l)
         s = l[l.index("/Length ")+8:]
         if ' ' in s:
             s = s[:s.index(" ")]
         if '>' in s:
             s = s[:s.index(">")]
         length = int(s)
-        print l, length
+        print("%s%s" % (l, length))
     if l.startswith('stream') and length:
         i += 1
         fn = "stream_%s_%s" % (i, sys.argv[1])
-        print "writing ", length, fn
+        print("writing  %s %s" % (length, fn))
         s = r.read(length)
         w = open(fn, 'wb')
         try:
@@ -32,7 +33,7 @@ while True:
         except zlib.error:
             pass
         if hex:
-            s = s.encode('hex')
+            s = hexlify(s)
         w.write(s)
         w.close()
 r.close()

--- a/tools/designer.py
+++ b/tools/designer.py
@@ -12,6 +12,8 @@
 
 "Visual Template designer for PyFPDF (using wxPython OGL library)"
 
+from __future__ import with_statement
+
 __author__ = "Mariano Reingart <reingart@gmail.com>"
 __copyright__ = "Copyright (C) 2011 Mariano Reingart"
 __license__ = "GPL 3.0"
@@ -535,20 +537,21 @@ class AppFrame(wx.Frame):
         
         self.do_new()
         tmp = []
-        for lno, linea in enumerate(open(self.filename).readlines()):
-            if DEBUG: print "processing line", lno, linea
-            args = []
-            for i,v in enumerate(linea.split(";")):
-                if not v.startswith("'"): 
-                    v = v.replace(",",".")
-                else:
-                    v = v#.decode('latin1')
-                if v.strip()=='':
-                    v = None
-                else:
-                    v = eval(v.strip())
-                args.append(v)
-            tmp.append(args)
+        with open(self.filename) as file:
+            for lno, linea in enumerate(file.readlines()):
+                if DEBUG: print "processing line", lno, linea
+                args = []
+                for i,v in enumerate(linea.split(";")):
+                    if not v.startswith("'"): 
+                        v = v.replace(",",".")
+                    else:
+                        v = v#.decode('latin1')
+                    if v.strip()=='':
+                        v = None
+                    else:
+                        v = eval(v.strip())
+                    args.append(v)
+                tmp.append(args)
         
         # sort by z-order (priority)
         for args in sorted(tmp, key=lambda t: t[-1]):
@@ -573,21 +576,20 @@ class AppFrame(wx.Frame):
             else:
                 return repr(v)
         
-        f = open(self.filename, "w")
-        for element in sorted(self.elements, key=lambda e:e.name):
-            if element.static:
-                continue
-            d = element.as_dict()
-            l = [d['name'], d['type'],
-                 d['x1'], d['y1'], d['x2'], d['y2'],
-                 d['font'], d['size'],
-                 d['bold'], d['italic'], d['underline'], 
-                 d['foreground'], d['background'],
-                 d['align'], d['text'], d['priority'], 
-                ]
-            f.write(";".join([csv_repr(v) for v in l]))
-            f.write("\n")
-        f.close()
+        with open(self.filename, "w") as f:
+            for element in sorted(self.elements, key=lambda e:e.name):
+                if element.static:
+                    continue
+                d = element.as_dict()
+                l = [d['name'], d['type'],
+                     d['x1'], d['y1'], d['x2'], d['y2'],
+                     d['font'], d['size'],
+                     d['bold'], d['italic'], d['underline'], 
+                     d['foreground'], d['background'],
+                     d['align'], d['text'], d['priority'], 
+                    ]
+                f.write(";".join([csv_repr(v) for v in l]))
+                f.write("\n")
         
     def do_print(self, evt):
         # genero el renderizador con propiedades del PDF

--- a/tools/designer.py
+++ b/tools/designer.py
@@ -466,7 +466,7 @@ class AppFrame(wx.Frame):
         canvas = self.canvas = ogl.ShapeCanvas( self )
         maxWidth  = 2000
         maxHeight = 2000
-        canvas.SetScrollbars(20, 20, maxWidth/20, maxHeight/20)
+        canvas.SetScrollbars(20, 20, maxWidth//20, maxHeight//20)
         sizer.Add( canvas, 1, wx.GROW )
 
         canvas.SetBackgroundColour("WHITE") #

--- a/tutorial/tuto3.py
+++ b/tutorial/tuto3.py
@@ -42,7 +42,7 @@ class PDF(FPDF):
 
 	def chapter_body(self,name):
 		#Read text file
-		txt=file(name).read()
+		txt=open(name,'rb').read().decode('latin1')
 		#Times 12
 		self.set_font('Times','',12)
 		#Output justified text

--- a/tutorial/tuto3.py
+++ b/tutorial/tuto3.py
@@ -1,3 +1,5 @@
+from __future__ import with_statement
+
 from fpdf import FPDF
 
 title='20000 Leagues Under the Seas'
@@ -42,7 +44,8 @@ class PDF(FPDF):
 
 	def chapter_body(self,name):
 		#Read text file
-		txt=open(name,'rb').read().decode('latin1')
+		with open(name,'rb') as file:
+			txt=file.read().decode('latin1')
 		#Times 12
 		self.set_font('Times','',12)
 		#Output justified text

--- a/tutorial/tuto4.py
+++ b/tutorial/tuto4.py
@@ -1,3 +1,5 @@
+from __future__ import with_statement
+
 from fpdf import *
 
 class PDF(FPDF):
@@ -59,7 +61,8 @@ class PDF(FPDF):
 
 	def chapter_body(self, fichier):
 		#Read text file
-		txt=open(fichier,'rb').read().decode('latin1')
+		with open(fichier,'rb') as stream:
+			txt=stream.read().decode('latin1')
 		#Font
 		self.set_font('Times','',12)
 		#Output text in a 6 cm width column

--- a/tutorial/tuto4.py
+++ b/tutorial/tuto4.py
@@ -59,7 +59,7 @@ class PDF(FPDF):
 
 	def chapter_body(self, fichier):
 		#Read text file
-		txt=file(fichier).read()
+		txt=open(fichier,'rb').read().decode('latin1')
 		#Font
 		self.set_font('Times','',12)
 		#Output text in a 6 cm width column

--- a/tutorial/tuto5.py
+++ b/tutorial/tuto5.py
@@ -5,7 +5,7 @@ class PDF(FPDF):
 	def load_data(self, name):
 		#Read file lines
 		data=[]
-		for line in file(name):
+		for line in open(name):
 			data += [line[:-1].split(';')]
 		return data
 

--- a/tutorial/tuto5.py
+++ b/tutorial/tuto5.py
@@ -1,3 +1,5 @@
+from __future__ import with_statement
+
 from fpdf import *
 
 class PDF(FPDF):
@@ -5,8 +7,9 @@ class PDF(FPDF):
 	def load_data(self, name):
 		#Read file lines
 		data=[]
-		for line in open(name):
-			data += [line[:-1].split(';')]
+		with open(name) as file:
+			for line in file:
+				data += [line[:-1].split(';')]
 		return data
 
 	#Simple table


### PR DESCRIPTION
These changes make more of the code compatible with Python 3, including when run with warnings enabled.

Some Python 3 things that aren’t addressed yet:

* According to setup.py, Python 3.2 is supported. But some files (tests, tutorials) use Python 2’s Unicode string `u". . ."` syntax. Python 3.3 added back support for this syntax, so we could just drop 3.2 and require 2.5+ or 3.3+.
* tools/designer.py requires WX Widgets. I was under the impression that WX does not support Python 3 very well, so I have not made any changes to that file for Python 3.
