### PR TITLE
Updated designer.py application

### DIFF
--- a/tools/designer.py
+++ b/tools/designer.py
@@ -284,14 +284,13 @@ class Element(object):
                 self.shape.SetBitmap(bmp)
                 self.shape.SetFilename(self.text)
                 shape = self.shape
-                shape.SetMaintainAspectRatio(True)
             else:
                 shape = self.shape = ogl.RectangleShape(w, h)
-                shape.SetMaintainAspectRatio(False)
                 
         else:
             shape = self.shape = ogl.RectangleShape(w, h)
-            shape.SetMaintainAspectRatio(False)
+        
+        shape.SetMaintainAspectRatio(False)
 
         if static:
             shape.SetDraggable(False)        
@@ -328,6 +327,7 @@ class Element(object):
                     foreground= 0x000000, background=0xFFFFFF,
                     align="L", text="", priority=0)
         data = CustomDialog.do_input(parent, 'New element', Class.fields, data)
+            
         if data:
             return Class(canvas=parent.canvas, frame=parent, **data)
     
@@ -973,3 +973,4 @@ if __name__ == "__main__":
     frame = AppFrame()
     app.MainLoop()
     app.Destroy()
+


### PR DESCRIPTION
CHANGES:

Made many changes to designer.py application, specially in its file management and image elements behaviors.  Previewing images is extremely useful when developing templates based on existing ones since you can use a scanned copy of the original as a guide.

**Menu**

1.  "Save As ..." is now working.
2.  Application will change current directory to working directory after using Open or Save file dialogs.
3. Now the application does not requires an existant template file to save new template.
4.  Added item "Template settings" to declare paper size and orientation to use when previewing document.
5. Removed unused items: Undo, Redo
6. Changed icon for Modify Item and place icon near other items related to actions over elements.

**Paper size guides**

1. Only one paper size guide will be visible at a time.
2. Guides are not draggable any more.
3. Guides can be changed via menu item "Template settings"
4. Status bar now indicates paper size and orientation. 
5. Default paper parameters can be changed through constants DEFAULT_PAPER_SIZE and DEFAULT_PAPER_ORIENTATION.

**Image elements**

1. Now it is possible to preview image elements while working with template.
2. Image elements can be resized. Aspect ratio ~~is respected~~ is NOT preserved.
3. Image elements by default are placed under all other elements, so insertion order of multiple images is important. This is useful when using image as background guide to replicate a form.

**About Info**

1. Updated link to Template's  documentation GitHub project.