### PR TITLE
Added support to images that come on URL format

### DIFF
--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -1763,7 +1763,7 @@ class FPDF(object):
         "Load external file"
         # by default loading from network is allowed for all images
         if reason == "image":
-            if filename.startswith("http://") or filename.startswith("https://"):
+            if filename.startswith("http://") or filename.startswith("https://") or filename.startswith("data:image/"):
                 f = BytesIO(urlopen(filename).read())
             else:
                 f = open(filename, "rb")


### PR DESCRIPTION
With this change, now you are able to use images encoded on base64 with URL format. Example: 

data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7
