### PR TITLE
when creating an image object, be able to use mask image

### DIFF
--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -988,7 +988,7 @@ class FPDF(object):
             self.cell(l/1000.0*self.font_size,h,substr(s,j),0,0,'',0,link)
 
     @check_page
-    def image(self, name, x=None, y=None, w=0,h=0,type='',link='', isMask=False, maskImg=0):
+    def image(self, name, x=None, y=None, w=0,h=0,type='',link='', is_mask=False, mask_image=None):
         "Put an image on the page"
         if not name in self.images:
             #First use of image, get info
@@ -1027,11 +1027,11 @@ class FPDF(object):
                     self.error('Unsupported image type: '+type)
                 info=getattr(self, mtd)(name)
             info['i']=len(self.images)+1
-            # isMask and maskImg
-            if isMask and info['cs'] != 'DeviceGray':
+            # is_mask and mask_image
+            if is_mask and info['cs'] != 'DeviceGray':
                 self.error('Mask must be a gray scale image')
-            if maskImg:
-                info['masked'] = maskImg
+            if mask_image:
+                info['masked'] = mask_image
             self.images[name]=info
         else:
             info=self.images[name]
@@ -1055,7 +1055,7 @@ class FPDF(object):
             self.y += h
         if x is None:
             x = self.x
-        if not isMask:
+        if not is_mask:
             self._out(sprintf('q %.2f 0 0 %.2f %.2f %.2f cm /I%d Do Q',w*self.k,h*self.k,x*self.k,(self.h-(y+h))*self.k,info['i']))
         if(link):
             self.link(x,y,w,h,link)
@@ -1572,7 +1572,7 @@ class FPDF(object):
             self._out('/Subtype /Image')
             self._out('/Width '+str(info['w']))
             self._out('/Height '+str(info['h']))
-            # set maskImg
+            # set mask object for this image
             if 'masked' in info:
                 self._out('/SMask ' + str(info['masked']['n']+1) + ' 0 R')
 

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -91,7 +91,7 @@ class FPDF(object):
         self.core_fonts={'courier': 'Courier', 'courierB': 'Courier-Bold',
             'courierI': 'Courier-Oblique', 'courierBI': 'Courier-BoldOblique',
             'helvetica': 'Helvetica', 'helveticaB': 'Helvetica-Bold',
-            'helveticaI': 'Helvetica-Oblique', 
+            'helveticaI': 'Helvetica-Oblique',
             'helveticaBI': 'Helvetica-BoldOblique',
             'times': 'Times-Roman', 'timesB': 'Times-Bold',
             'timesI': 'Times-Italic', 'timesBI': 'Times-BoldItalic',
@@ -197,10 +197,10 @@ class FPDF(object):
 
     def set_display_mode(self, zoom,layout='continuous'):
         """Set display mode in viewer
-        
+
         The "zoom" argument may be 'fullpage', 'fullwidth', 'real',
         'default', or a number, interpreted as a percentage."""
-        
+
         if(zoom=='fullpage' or zoom=='fullwidth' or zoom=='real' or zoom=='default' or not isinstance(zoom,basestring)):
             self.zoom_mode=zoom
         else:
@@ -453,23 +453,23 @@ class FPDF(object):
         lx = 4.0/3.0*(math.sqrt(2)-1)*rx
         ly = 4.0/3.0*(math.sqrt(2)-1)*ry
 
-        self._out(sprintf('%.2f %.2f m %.2f %.2f %.2f %.2f %.2f %.2f c', 
-            (cx+rx)*self.k, (self.h-cy)*self.k, 
-            (cx+rx)*self.k, (self.h-(cy-ly))*self.k, 
-            (cx+lx)*self.k, (self.h-(cy-ry))*self.k, 
+        self._out(sprintf('%.2f %.2f m %.2f %.2f %.2f %.2f %.2f %.2f c',
+            (cx+rx)*self.k, (self.h-cy)*self.k,
+            (cx+rx)*self.k, (self.h-(cy-ly))*self.k,
+            (cx+lx)*self.k, (self.h-(cy-ry))*self.k,
             cx*self.k, (self.h-(cy-ry))*self.k))
-        self._out(sprintf('%.2f %.2f %.2f %.2f %.2f %.2f c', 
-            (cx-lx)*self.k, (self.h-(cy-ry))*self.k, 
-            (cx-rx)*self.k, (self.h-(cy-ly))*self.k, 
+        self._out(sprintf('%.2f %.2f %.2f %.2f %.2f %.2f c',
+            (cx-lx)*self.k, (self.h-(cy-ry))*self.k,
+            (cx-rx)*self.k, (self.h-(cy-ly))*self.k,
             (cx-rx)*self.k, (self.h-cy)*self.k))
-        self._out(sprintf('%.2f %.2f %.2f %.2f %.2f %.2f c', 
-            (cx-rx)*self.k, (self.h-(cy+ly))*self.k, 
-            (cx-lx)*self.k, (self.h-(cy+ry))*self.k, 
+        self._out(sprintf('%.2f %.2f %.2f %.2f %.2f %.2f c',
+            (cx-rx)*self.k, (self.h-(cy+ly))*self.k,
+            (cx-lx)*self.k, (self.h-(cy+ry))*self.k,
             cx*self.k, (self.h-(cy+ry))*self.k))
-        self._out(sprintf('%.2f %.2f %.2f %.2f %.2f %.2f c %s', 
-            (cx+lx)*self.k, (self.h-(cy+ry))*self.k, 
-            (cx+rx)*self.k, (self.h-(cy+ly))*self.k, 
-            (cx+rx)*self.k, (self.h-cy)*self.k, 
+        self._out(sprintf('%.2f %.2f %.2f %.2f %.2f %.2f c %s',
+            (cx+lx)*self.k, (self.h-(cy+ry))*self.k,
+            (cx+rx)*self.k, (self.h-(cy+ly))*self.k,
+            (cx+rx)*self.k, (self.h-cy)*self.k,
             op))
 
     def add_font(self, family, style='', fname='', uni=False):
@@ -501,7 +501,7 @@ class FPDF(object):
             name = ''
             if FPDF_CACHE_MODE == 0:
                 unifilename = os.path.splitext(ttffilename)[0] + '.pkl'
-            elif FPDF_CACHE_MODE == 2:                
+            elif FPDF_CACHE_MODE == 2:
                 unifilename = os.path.join(FPDF_CACHE_DIR, \
                     hashpath(ttffilename) + ".pkl")
             else:
@@ -988,7 +988,7 @@ class FPDF(object):
             self.cell(l/1000.0*self.font_size,h,substr(s,j),0,0,'',0,link)
 
     @check_page
-    def image(self, name, x=None, y=None, w=0,h=0,type='',link=''):
+    def image(self, name, x=None, y=None, w=0,h=0,type='',link='', isMask=False, maskImg=0):
         "Put an image on the page"
         if not name in self.images:
             #First use of image, get info
@@ -1027,6 +1027,11 @@ class FPDF(object):
                     self.error('Unsupported image type: '+type)
                 info=getattr(self, mtd)(name)
             info['i']=len(self.images)+1
+            # isMask and maskImg
+            if isMask and info['cs'] != 'DeviceGray':
+                self.error('Mask must be a gray scale image')
+            if maskImg:
+                info['masked'] = maskImg
             self.images[name]=info
         else:
             info=self.images[name]
@@ -1050,9 +1055,12 @@ class FPDF(object):
             self.y += h
         if x is None:
             x = self.x
-        self._out(sprintf('q %.2f 0 0 %.2f %.2f %.2f cm /I%d Do Q',w*self.k,h*self.k,x*self.k,(self.h-(y+h))*self.k,info['i']))
+        if not isMask:
+            self._out(sprintf('q %.2f 0 0 %.2f %.2f %.2f cm /I%d Do Q',w*self.k,h*self.k,x*self.k,(self.h-(y+h))*self.k,info['i']))
         if(link):
             self.link(x,y,w,h,link)
+
+        return info
 
     @check_page
     def ln(self, h=''):
@@ -1093,11 +1101,11 @@ class FPDF(object):
 
     def output(self, name='',dest=''):
         """Output PDF to some destination
-        
+
         By default the PDF is written to sys.stdout. If a name is given, the
         PDF is written to a new file. If dest='S' is given, the PDF data is
         returned as a byte string."""
-        
+
         #Finish document if necessary
         if(self.state<3):
             self.close()
@@ -1450,7 +1458,7 @@ class FPDF(object):
         else:
             cw127fname = None
         font_dict = load_cache(cw127fname)
-        if font_dict is None:    
+        if font_dict is None:
             rangeid = 0
             range_ = {}
             range_interval = {}
@@ -1547,7 +1555,7 @@ class FPDF(object):
     def _putimages(self):
         filter=''
         if self.compress:
-            filter='/Filter /FlateDecode '            
+            filter='/Filter /FlateDecode '
         i = [(x[1]["i"],x[1]) for x in self.images.items()]
         i.sort()
         for idx,info in i:
@@ -1564,6 +1572,10 @@ class FPDF(object):
             self._out('/Subtype /Image')
             self._out('/Width '+str(info['w']))
             self._out('/Height '+str(info['h']))
+            # set maskImg
+            if 'masked' in info:
+                self._out('/SMask ' + str(info['masked']['n']+1) + ' 0 R')
+
             if(info['cs']=='Indexed'):
                 self._out('/ColorSpace [/Indexed /DeviceRGB '+str(len(info['pal'])//3-1)+' '+str(self.n+1)+' 0 R]')
             else:
@@ -1731,7 +1743,7 @@ class FPDF(object):
             if orientation == 'P':
                 self.w_pt = self.fw_pt
                 self.h_pt = self.fh_pt
-            else:                    
+            else:
                 self.w_pt = self.fh_pt
                 self.h_pt = self.fw_pt
             self.w = self.w_pt / self.k
@@ -1966,9 +1978,9 @@ class FPDF(object):
         #Add a line to the document
         if PY3K and isinstance(s, bytes):
             # manage binary data as latin1 until PEP461-like function is implemented
-            s = s.decode("latin1")          
+            s = s.decode("latin1")
         elif not PY3K and isinstance(s, unicode):
-            s = s.encode("latin1")    # default encoding (font name and similar)      
+            s = s.encode("latin1")    # default encoding (font name and similar)
         elif not isinstance(s, basestring):
             s = str(s)
         if(self.state == 2):
@@ -2055,5 +2067,3 @@ class FPDF(object):
                     self.rect(x, y, dim[d], h, 'F')
                 x += dim[d]
             x += dim['n']
-
-


### PR DESCRIPTION
Inspired by http://www.fpdf.org/en/script/script83.php

`image` API returns `info` which can be used as a mask.

Example: 

```
pdf = FPDF()
pdf.add_page()
mask = pdf.image('./mask.png', is_mask=True)
pdf.image('./image.jpg', 40.0, 60.0, w=120, mask_image=mask)
pdf.image('./image2.jpg', 40.0, 180.0, h=20, mask_image=mask)
pdf.image('./image.png', 40.0, 180, w=120, mask_image=mask)
pdf.output('./test.pdf', 'F')
```

mask image can be used as mask for multiple images

for png files with internal alpha channels, the internal alpha channels take effect.

[mask.png](https://cloud.githubusercontent.com/assets/738445/23298563/1d32f7b2-fab9-11e6-8f68-d3345f247368.png)
[image.jpg](https://cloud.githubusercontent.com/assets/738445/23298562/1d2fc4c0-fab9-11e6-8ebb-aa59dd867f6f.jpg)
[image2.jpg](https://cloud.githubusercontent.com/assets/738445/23298561/1d2f4036-fab9-11e6-905e-aca20745fd59.jpg)
[image.png](https://cloud.githubusercontent.com/assets/738445/23298564/1d3381d2-fab9-11e6-97d7-a92178dc96c3.png)


[test.pdf](https://github.com/reingart/pyfpdf/files/798869/test.pdf)
