### PR TITLE
fix: getGlyph() on the last glyph results in incorrect "missing glyph"

### DIFF
--- a/fpdf/ttfonts.py
+++ b/fpdf/ttfonts.py
@@ -943,13 +943,15 @@ class TTFontFile:
         if (indexToLocFormat == 0):
             data = self.get_chunk(start,(numGlyphs*2)+2)
             arr = unpack(">%dH" % (len(data)//2), data)
-            for n in range(numGlyphs): 
-                self.glyphPos.append((arr[n] * 2))  # n+1 !?
+            for n in range(len(arr)):
+                # NOTE: len(arr) == numGlyphs + 1, otherwise
+                # the length of the last glyph would be unknown.
+                self.glyphPos.append((arr[n] * 2))
         elif (indexToLocFormat == 1):
             data = self.get_chunk(start,(numGlyphs*4)+4)
             arr = unpack(">%dL" % (len(data)//4), data)
-            for n in range(numGlyphs):
-                self.glyphPos.append((arr[n]))  # n+1 !?
+            for n in range(len(arr)):
+                self.glyphPos.append((arr[n]))
         else:
             die('Unknown location table format ' + indexToLocFormat)
 


### PR DESCRIPTION
I ran into this issue when using a code128 barcode font (https://github.com/Holger-Will/code-128-font/blob/master/fonts/code128_L.ttf to be specific). The last glyph of the barcode never rendered and resulted in a "missing glyph" warning.

This PR fixes that (and likely explains the original `# n+1 !?` comment).