### PR TITLE
add ability to set bottom margin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Installation Instructions:
 To get the latest development version you can download the source code running:
 
 ```
-   git clone https://github.com/reingart/pyfpdf.git
+   git clone https://github.com/worraps/pyfpdf.git
    cd pyfpdf
    python setup.py install
 ```

--- a/docs/reference/set_margins.md
+++ b/docs/reference/set_margins.md
@@ -1,12 +1,12 @@
 ## set_margins ##
 
 ```python
-fpdf.set_margins(left: float, top: float, right: float = -1)
+fpdf.set_margins(left: float, top: float, right: float = -1, bottom: float = -1)
 ```
 
 ### Description ###
 
-Defines the left, top and right margins. By default, they equal 1 cm. Call this method to change them.
+Defines the left, top, right and bottom margins. By default left, top and right equal 1 cm and bottom double the top. Call this method to change them.
 
 ### Parameters ###
 
@@ -18,6 +18,9 @@ top:
 
 right:
 > Right margin. Default value is the left one.
+
+bottom:
+> Bottom margin. Default value is double the top one.
 
 ### See also ###
 

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -87,6 +87,7 @@ class FPDF(object):
         self.color_flag = 0             # indicates whether fill and text colors are different
         self.ws = 0                     # word spacing
         self.angle = 0
+        self.auto_page_break=1          #assume we will want an auto page break
         # Standard fonts
         self.core_fonts={'courier': 'Courier', 'courierB': 'Courier-Bold',
             'courierI': 'Courier-Oblique', 'courierBI': 'Courier-BoldOblique',
@@ -167,13 +168,17 @@ class FPDF(object):
                 return fn(self, *args, **kwargs)
         return wrapper
 
-    def set_margins(self, left,top,right=-1):
+    def set_margins(self, left,top,right=-1,bottom=-1):
         "Set left, top and right margins"
         self.l_margin=left
         self.t_margin=top
         if(right==-1):
             right=left
         self.r_margin=right
+        if(bottom==-1):
+            bottom=top*2 #default bottom to double top
+        #reset bottom margin
+        self.set_auto_page_break(self.auto_page_break,bottom)
 
     def set_left_margin(self, margin):
         "Set left margin"


### PR DESCRIPTION
This is useful for spool type label printers.  Default bottom margin is too big.  Need to be able to set bottom margin.
See #148 for example