### PR TITLE
Fixed JPEGs not being closed correctly

### DIFF
--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -1813,10 +1813,11 @@ class FPDF(object):
                 f.close()
             self.error('Missing or incorrect image file: %s. error: %s' % (filename, str(exception())))
 
-        with f:
             # Read whole file from the start
             f.seek(0)
             data = f.read()
+            f.close()
+            
         return {'w':width,'h':height,'cs':colspace,'bpc':bpc,'f':'DCTDecode','data':data}
 
     def _parsegif(self, filename):


### PR DESCRIPTION
Currently, when a JPEG image() is added to a PDF, the file is not properly closed. This prevents modifying the files until the entire program has quit. This pull request essentially changes 1 line in order to properly close JPEG files once they are done being used by PyFPDF.