### PR TITLE
Deprecating .rotate() and introducing .rotation() context manager

### DIFF
--- a/docs/reference/rotate.md
+++ b/docs/reference/rotate.md
@@ -4,42 +4,21 @@
 rotate(angle: float, x = None, y = None)
 ```
 
-### Description ###
+### DEPRECATED ###
 
-This method allows to perform a rotation around a given center.
+This method is **deprecated** because it can produce malformed PDFs.
 
-The rotation affects all elements which are printed after the method call 
-(with the exception of clickable areas).
-
-Remarks:
-
-Only the display is altered. The get_x() and get_y() methods are not affected, 
-nor the automatic page break mechanism. Rotation is not kept from page to page.
-Each page begins with a null rotation. Note: this behaviour are subject to 
-change.
-
-### Parameters ###
-
-angle: 
-> Angle in degrees.
-
-x:
-> Abscissa of the rotation center. Default value: current position.
-
-y:
-> Ordinate of the rotation center. Default value: current position.
-
-### Example ###
+Example of code generating an invalid PDF:
 ```python
-pdf.set_font('Arial', '', 14)
+pdf = fpdf.FPDF()
 pdf.add_page()
-# Rotate all consequenced operations
-pdf.rotate(-30)
-pdf.write(5, "Rotated")
-pdf.write(5, " text")
+pdf.rotate(90)
+pdf.image("lena.gif")
+# Not calling pdf.angle(0) before switching to a new page causes the issue
+pdf.add_page()
+pdf.rotate(90)
+pdf.image("lena.gif")
+pdf.output("out.pdf")
 ```
 
-### See also ###
-
-[set_x](set_x.md), [set_y](set_y.md), [write](write.md)
-
+Use the [rotation()](rotation.md) context manager instead.

--- a/docs/reference/rotation.md
+++ b/docs/reference/rotation.md
@@ -1,0 +1,43 @@
+## rotation ##
+
+```python
+with rotation(angle: float, x: float = None, y: float = None):
+    ...
+```
+
+### Description ###
+
+This method allows to perform a rotation around a given center.
+
+The rotation affects all elements which are printed inside the indented context
+(with the exception of clickable areas).
+
+Remarks:
+
+Only the rendering is altered. The get_x() and get_y() methods are not affected,
+nor the automatic page break mechanism.
+
+### Parameters ###
+
+angle:
+> Angle in degrees.
+
+x:
+> Abscissa of the rotation center. Default value: current position.
+
+y:
+> Ordinate of the rotation center. Default value: current position.
+
+### Example ###
+```python
+pdf.set_font('Arial', '', 14)
+pdf.add_page()
+# Rotate all consequenced operations
+with rotation(-30):
+    pdf.write(5, "Rotated text")
+pdf.write(5, "Horizontal text")
+```
+
+### See also ###
+
+[set_x](set_x.md), [set_y](set_y.md), [write](write.md)

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -17,9 +17,7 @@ from __future__ import division, with_statement
 
 from datetime import datetime
 from functools import wraps
-import math
-import errno
-import os, sys, zlib, struct, re, tempfile, struct
+import contextlib, errno, math, os, re, struct, sys, tempfile, warnings, zlib
 
 from .ttfonts import TTFontFile
 from .fonts import fpdf_charwidths
@@ -692,6 +690,8 @@ class FPDF(object):
 
     @check_page
     def rotate(self, angle, x=None, y=None):
+        warnings.warn('rotate() can produces malformed PDFs and is deprecated. Use the rotation() context manager instead.',
+                      PendingDeprecationWarning)
         if x is None:
             x = self.x
         if y is None:
@@ -707,6 +707,20 @@ class FPDF(object):
             cy = (self.h-y)*self.k
             s = sprintf('q %.5F %.5F %.5F %.5F %.2F %.2F cm 1 0 0 1 %.2F %.2F cm',c,s,-s,c,cx,cy,-cx,-cy)
             self._out(s)
+
+    @check_page
+    @contextlib.contextmanager
+    def rotation(self, angle, x=None, y=None):
+        if x is None:
+            x = self.x
+        if y is None:
+            y = self.y;
+        angle *= math.pi / 180
+        c, s = math.cos(angle), math.sin(angle)
+        cx, cy = x*self.k, (self.h-y)*self.k
+        self._out(sprintf('q %.5F %.5F %.5F %.5F %.2F %.2F cm 1 0 0 1 %.2F %.2F cm\n', c, s, -s, c, cx, cy, -cx, -cy))
+        yield
+        self._out('Q\n')
 
     def accept_page_break(self):
         "Accept automatic page break or not"

--- a/fpdf/template.py
+++ b/fpdf/template.py
@@ -129,11 +129,12 @@ class Template:
                 #print "dib",element['type'], element['name'], element['x1'], element['y1'], element['x2'], element['y2']
                 element = element.copy()
                 element['text'] = self.texts[pg].get(element['name'].lower(), element['text'])
+                handler_name = element['type'].upper()
                 if 'rotate' in element:
-                    pdf.rotate(element['rotate'], element['x1'], element['y1'])
-                self.handlers[element['type'].upper()](pdf, **element)
-                if 'rotate' in element:
-                    pdf.rotate(0)
+                    with pdf.rotation(element['rotate'], element['x1'], element['y1']):
+                        self.handlers[handler_name](pdf, **element)
+                else:
+                    self.handlers[handler_name](pdf, **element)
         
         if dest:
             return pdf.output(outfile, dest)

--- a/tests/cover/test_rotation.py
+++ b/tests/cover/test_rotation.py
@@ -1,0 +1,28 @@
+
+# -*- coding: utf-8 -*-
+
+"Basic test for rotation"
+
+#PyFPDF-cover-test:format=PDF
+#PyFPDF-cover-test:fn=rotation.pdf
+#PyFPDF-cover-test:hash=5dbe8d24682841efaccc5b48e590111e
+
+import os
+import common
+from fpdf import FPDF
+
+@common.add_unittest
+def dotest(outputname, nostamp):
+    pdf = FPDF()
+    if nostamp:
+        pdf._putinfo = lambda: common.test_putinfo(pdf)
+
+    pdf.add_page()
+
+    with pdf.rotation(90, x=16, y=16):
+        pdf.image(os.path.join(common.basepath, "lena.gif"), x=0, y=0)
+
+    pdf.output(outputname, 'F')
+
+if __name__ == "__main__":
+    common.testmain(__file__, dotest)


### PR DESCRIPTION
Minimal Python code reproducng the issue with the current `rotate` method:
```python
pdf = fpdf.FPDF()
pdf.add_page()
pdf.rotate(90)
pdf.image("lena.gif")
pdf.add_page()
pdf.rotate(90)
pdf.image("lena.gif")
pdf.output("out.pdf")
```

The generated file contains the following stream:
```
2 J
0.57 w
Q
q 0.00000 1.00000 -1.00000 0.00000 28.35 813.54 cm 1 0 0 1 -28.35 -813.54 cm
q 128.00 0 0 128.00 28.35 685.54 cm /I1 Do Q
```

Notice the invalid leading `Q` operator.

This issue was detected using Datalogics PDF Checker