### PR TITLE
Adding support for Contents alt text on Links

### DIFF
--- a/docs/reference/link.md
+++ b/docs/reference/link.md
@@ -1,7 +1,7 @@
 ## link ##
 
 ```python
-fpdf.link(x: float, y: float, w: float, h: float, link)
+fpdf.link(x: float, y: float, w: float, h: float, link, alt_text = '')
 ```
 
 ### Description ###
@@ -24,6 +24,9 @@ h:
 
 link:
 > URL or identifier returned by [add_link](add_link.md).
+
+alt_text:
+> An optional string defining the link alternative text `Contents`
 
 ### See also ###
 

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -667,11 +667,11 @@ class FPDF(object):
             page=self.page
         self.links[link]=[page,y]
 
-    def link(self, x,y,w,h,link):
+    def link(self, x,y,w,h,link, alt_text=''):
         "Put a link on the page"
         if not self.page in self.page_links:
             self.page_links[self.page] = []
-        self.page_links[self.page] += [(x*self.k,self.h_pt-y*self.k,w*self.k,h*self.k,link),]
+        self.page_links[self.page] += [(x*self.k,self.h_pt-y*self.k,w*self.k,h*self.k,link,alt_text),]
 
     @check_page
     def text(self, x, y, txt=''):
@@ -1204,15 +1204,18 @@ class FPDF(object):
                         rect + '] /Border [0 0 0] '
                     if isinstance(pl[4], basestring):
                         annots += '/A <</S /URI /URI ' + \
-                            self._textstring(pl[4]) + '>>>>'
+                            self._textstring(pl[4]) + '>>'
                     else:
                         l = self.links[pl[4]]
                         if l[0] in self.orientation_changes:
                             h = w_pt
                         else:
                             h = h_pt
-                        annots += sprintf('/Dest [%d 0 R /XYZ 0 %.2f null]>>',
+                        annots += sprintf('/Dest [%d 0 R /XYZ 0 %.2f null]',
                             1 + 2 * l[0], h - l[1] * self.k)
+                    if pl[5]:
+                        annots += sprintf('/Contents (%s)', pl[5])
+                    annots += '>>'
                 self._out(annots + ']')
             if self.pdf_version > '1.3':
                 self._out("/Group <</Type /Group /S /Transparency"\


### PR DESCRIPTION
I tested this and the optional alt text gets displayed well as a tooltip by Sumatra PDF:
![2020-08-08 15_18_30-wip pdf - SumatraPDF](https://user-images.githubusercontent.com/925560/89711708-42590300-d98c-11ea-9965-0d6d6acd31f4.png)
