### PR TITLE
Making FPDF.output() x100 time faster by using a bytearray buffer

### DIFF
--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -64,7 +64,7 @@ class FPDF(object):
         self.offsets = {}               # array of object offsets
         self.page = 0                   # current page number
         self.n = 2                      # current object number
-        self.buffer = ''                # buffer holding in-memory PDF
+        self.buffer = bytearray()       # buffer holding in-memory PDF
         self.pages = {}                 # array containing pages and metadata
         self.state = 0                  # current document state
         self.fonts = {}                 # array of used fonts
@@ -1115,22 +1115,17 @@ class FPDF(object):
                 dest='I'
             else:
                 dest='F'
-        if PY3K:
-            # manage binary data as latin1 until PEP461 or similar is implemented
-            buffer = self.buffer.encode("latin1")
-        else:
-            buffer = self.buffer
         if dest in ('I', 'D'):
             # Python < 3 writes byte data transparently without "buffer"
             stdout = getattr(sys.stdout, 'buffer', sys.stdout)
-            stdout.write(buffer)
+            stdout.write(self.buffer)
         elif dest=='F':
             #Save to local file
             with open(name,'wb') as f:
-                f.write(buffer)
+                f.write(self.buffer)
         elif dest=='S':
             #Return as a byte string
-            return buffer
+            return self.buffer
         else:
             self.error('Incorrect output destination: '+dest)
 
@@ -1986,7 +1981,7 @@ class FPDF(object):
         if(self.state == 2):
             self.pages[self.page]["content"] += (s + "\n")
         else:
-            self.buffer += (s + "\n")
+            self.buffer += (s.encode("latin1") + b"\n")
 
     @check_page
     def interleaved2of5(self, txt, x, y, w=1.0, h=10.0):

--- a/fpdf/php.py
+++ b/fpdf/php.py
@@ -25,11 +25,7 @@ def UTF8ToUTF16BE(instr, setbom=True):
         outstr += "\xFE\xFF".encode("latin1")
     if not isinstance(instr, unicode):
         instr = instr.decode('UTF-8')
-    outstr += instr.encode('UTF-16BE')
-    # convert bytes back to fake unicode string until PEP461-like is implemented
-    if PY3K:
-        outstr = outstr.decode("latin1")
-    return outstr
+    return outstr + instr.encode('UTF-16BE')
 
 def UTF8StringToArray(instr):
     "Converts UTF-8 strings to codepoints array"


### PR DESCRIPTION
There is a detailed article explaining why this is faster:
https://www.guyrutenberg.com/2020/04/04/fast-bytes-concatenation-in-python/

On a document I'm working on with over 12 000 pages,
thanks to this patch the output generation passed from taking 20 minutes to 2 seconds.