### PR TITLE
Add support for C39 in templates

### DIFF
--- a/docs/ReferenceManual.md
+++ b/docs/ReferenceManual.md
@@ -11,6 +11,8 @@
   * [add_link](reference/add_link.md) - create an internal link
   * [add_page](reference/add_page.md) - add a new page
   * [alias_nb_pages](reference/alias_nb_pages.md) - define an alias for number of pages
+  * [interleaved2of5](reference/interleaved2of5.md) - add a new barcode with Interleaved 2 of 5 schema
+  * [code39](reference/code39.md) - add a new barcode with C39 schema
   * [cell](reference/cell.md) - print a cell
   * [close](reference/close.md) - terminate the document
   * [error](reference/error.md) - fatal error
@@ -54,7 +56,7 @@
   * [write](reference/write.md) - print flowing text
 
 ## Additional API ##
-  
+
 These features are not available in the original FPDF and were implemented after forking.
 
   * [dashed_line](reference/dashed_line.md) - draw a dashed line
@@ -63,4 +65,3 @@ These features are not available in the original FPDF and were implemented after
   * [set_doc_option](reference/set_doc_option.md) - set document options
   * [set_stretching](reference/set_stretching.md) - set horizontal font stretching
   * [write_html](reference/write_html.md) - print text with HTML markup
-

--- a/docs/Templates.md
+++ b/docs/Templates.md
@@ -17,7 +17,9 @@ The header contains the page format, title of the document and other metadata.
 Elements have the following properties (columns in a CSV, fields in a database):
 
   * name: placeholder identification
-  * type: 'T': texts, 'L': lines, 'I': images, 'B': boxes, 'BC': barcodes
+  * type: 'T': texts, 'L': lines, 'I': images, 'B': boxes, 'BC': barcodes (Interleaved
+    2 of 5) - alias for BCI25, 'BCI25': barcodes (Interleaved 2 of 5), 'BCC39': barcodes
+    (C39),
   * x1, y1, x2, y2: top-left, bottom-right coordinates (in mm)
   * font: e.g. "Arial"
   * size: text size in points, e.g. 10
@@ -45,7 +47,7 @@ Note the following, the definition of a template will contain the elements. The 
 
 from fpdf import Template
 
-#this will define the ELEMENTS that will compose the template. 
+#this will define the ELEMENTS that will compose the template.
 elements = [
     { 'name': 'company_logo', 'type': 'I', 'x1': 20.0, 'y1': 17.0, 'x2': 78.0, 'y2': 30.0, 'font': None, 'size': 0.0, 'bold': 0, 'italic': 0, 'underline': 0, 'foreground': 0, 'background': 0, 'align': 'I', 'text': 'logo', 'priority': 2, },
     { 'name': 'company_name', 'type': 'T', 'x1': 17.0, 'y1': 32.5, 'x2': 115.0, 'y2': 37.5, 'font': 'Arial', 'size': 12.0, 'bold': 1, 'italic': 0, 'underline': 0, 'foreground': 0, 'background': 0, 'align': 'I', 'text': '', 'priority': 2, },

--- a/docs/reference/code39.md
+++ b/docs/reference/code39.md
@@ -1,0 +1,38 @@
+## code39 ##
+
+```python
+fpdf.code39(txt: str, x: float, y: float, w=1.5, h=5.0)
+```
+
+### Description ###
+
+Add a new barcode following C39 schema.
+
+### Parameters ###
+
+txt:
+> The text to be represented by the barcode.
+> Method accepts characters from following list: `'0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-. $/+%'`.
+To be more precise, it's equal to following expression:
+`string.digits + string.ascii_uppercase + '-. $/+%'`,. Take a not, method also
+accepts `'*'`, but this character is used to escape barcode text and shouldn't be used
+to code text.
+
+x:
+> Abscissa of upper-left barcode.
+
+y:
+> Ordinate of upper-left barcode.
+
+w:
+> Width of rectangles the barcode is built on. For example `0` is represented
+by `nnnwwnwnn` where 'w' is a rectangle with width equals to `w` and 'n' is equal to
+`w/3`
+
+h:
+> Height of the barcode
+
+
+### See also ###
+
+[interleaved2of5](interleaved2of5.md)

--- a/docs/reference/interleaved2of5.md
+++ b/docs/reference/interleaved2of5.md
@@ -1,0 +1,36 @@
+## interleaved2of5 ##
+
+```python
+fpdf.interleaved2of5(txt: str, x: float, y: float, w=1.0, h=10.0)
+```
+
+### Description ###
+
+Add a new barcode following Interleaved 2 of 5 schema.
+
+### Parameters ###
+
+txt:
+> The text to be represented by the barcode.
+> Method accepts string containing only digits. Take a note, 'A' and 'Z' are
+also accepted (do not couse an error), but they lead to generate incorrect
+barcodes as those characters are used to escape barcode.
+
+x:
+> Abscissa of upper-left barcode.
+
+y:
+> Ordinate of upper-left barcode.
+
+w:
+> Width of rectangles the barcode is built on. For example `0` is represented
+by `nnwwn` where 'w' is a rectangle with width equals to `w` and 'n' is equal to
+`w/3`
+
+h:
+> Height of the barcode
+
+
+### See also ###
+
+[code39](code39.md)

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -2059,7 +2059,9 @@ class FPDF(object):
             '+': 'nwnnnwnwn', '%': 'nnnwnwnwn',
         }
         self.set_fill_color(0)
-        for c in txt.upper():
+        code = '*' + txt.upper() + '*'
+
+        for c in code:
             if c not in chars:
                 raise RuntimeError('Invalid char "%s" for Code39' % c)
             for i, d in enumerate(chars[c]):


### PR DESCRIPTION
This pull request adds support for barcode following C39 in templates (`BCC39`). It also extends an interface to be consistent with barcodes in template - `I25` (`BCI25`) is explicitly added which call the same function as `BC`. `BC` is not changed to provide backwards compatibility. 

This pull request also introduces a change in `code39` method from `FPDF` class (responsible for barcode generation following C39 standard). Since now, it is not required to escape text on your own (adding '*' at the beginning and at the end of the string). This change does not provide backwards compatibility.