### PR TITLE
Workaround

### DIFF
--- a/fpdf/html.py
+++ b/fpdf/html.py
@@ -397,6 +397,6 @@ class HTMLMixin(object):
     def write_html(self, text, image_map=None):
         "Parse HTML and convert it to PDF"
         h2p = HTML2FPDF(self, image_map)
-        text = h2p.unescape(text) # To deal with HTML entities
+        # text = h2p.unescape(text) # To deal with HTML entities
         h2p.feed(text)
 


### PR DESCRIPTION
AttributeError: 'HTML2FPDF' object has no attribute 'unescape'