### PR TITLE
unescape() not supported and not required as of python 3.9 onwards

### DIFF
--- a/fpdf/html.py
+++ b/fpdf/html.py
@@ -397,6 +397,7 @@ class HTMLMixin(object):
     def write_html(self, text, image_map=None):
         "Parse HTML and convert it to PDF"
         h2p = HTML2FPDF(self, image_map)
-        text = h2p.unescape(text) # To deal with HTML entities
+        # unescape() not supported and not required as of python 3.9 onwards
+        # text = h2p.unescape(text) # To deal with HTML entities
         h2p.feed(text)
 


### PR DESCRIPTION
unescape() not supported and not required as of python 3.9 onwards