### PR TITLE
Added method to add custom HTTP headers

### DIFF
--- a/docs/reference/load_resource.md
+++ b/docs/reference/load_resource.md
@@ -9,8 +9,10 @@ fpdf.load_resource(reason: string, filename: string)
 This method is used to load external resources, such as images. It is 
 automatically called when resource added to document by [image](image.md). The 
 implementation in library sre try to load resource from local file system or 
-from network if filename starts with `http://` or `https://`. This method can 
-be overrided within subclass if you want a specific processing. 
+from network if filename starts with `http://` or `https://`. With the HTTP request
+custom headers set using method [set_http_request_header](set_http_request_header) is
+also passed. This method can be overrided within subclass if you want a specific processing. 
+
 
 Returns file-like object.
 
@@ -25,4 +27,5 @@ filename:
 ### See also ###
 
 [image](image.md).
+[set_http_request_header](set_http_request_header)
 

--- a/docs/reference/set_http_request_header.md
+++ b/docs/reference/set_http_request_header.md
@@ -1,0 +1,13 @@
+## set_http_request_header ##
+
+```python
+fpdf.set_http_request_header({'User-agent': 'Mozilla/5.0', 'auth_token': '23894138'})
+```
+### Description ###
+
+Sets custom HTTP headers to be passed with HTTP requests. 
+
+### Parameters ###
+
+header:
+> Dict of custom header values

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -144,6 +144,8 @@ class FPDF(object):
         self.set_compression(1)
         # Set default PDF version number
         self.pdf_version = '1.3'
+        # Set HTTP request header
+        self.http_request_header = {} 
 
     @staticmethod
     def get_page_format(format, k):
@@ -1776,9 +1778,8 @@ class FPDF(object):
         # by default loading from network is allowed for all images
         if reason == "image":
             if filename.startswith("http://") or filename.startswith("https://"):
-                custom_request = Request(filename)
-                custom_request.add_header('User-agent', 'Mozilla/5.0')
-                f = BytesIO(urlopen(custom_request).read())
+                prepared_request = Request(filename, headers=self.http_request_header)
+                f = BytesIO(urlopen(prepared_request).read())
             else:
                 f = open(filename, "rb")
             return f
@@ -2069,3 +2070,7 @@ class FPDF(object):
                     self.rect(x, y, dim[d], h, 'F')
                 x += dim[d]
             x += dim['n']
+    
+    def set_http_request_header(self, header):
+        self.http_request_header = header
+

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -24,7 +24,7 @@ import os, sys, zlib, struct, re, tempfile, struct
 from .ttfonts import TTFontFile
 from .fonts import fpdf_charwidths
 from .php import substr, sprintf, print_r, UTF8ToUTF16BE, UTF8StringToArray
-from .py3k import PY3K, pickle, urlopen, BytesIO, Image, basestring, unicode, exception, b, hashpath
+from .py3k import PY3K, pickle, urlopen, BytesIO, Image, basestring, unicode, exception, b, hashpath, Request
 
 # Global variables
 FPDF_VERSION = '1.7.2'
@@ -1776,7 +1776,9 @@ class FPDF(object):
         # by default loading from network is allowed for all images
         if reason == "image":
             if filename.startswith("http://") or filename.startswith("https://"):
-                f = BytesIO(urlopen(filename).read())
+                custom_request = Request(filename)
+                custom_request.add_header('User-agent', 'Mozilla/5.0')
+                f = BytesIO(urlopen(custom_request).read())
             else:
                 f = open(filename, "rb")
             return f

--- a/fpdf/py3k.py
+++ b/fpdf/py3k.py
@@ -14,8 +14,10 @@ except ImportError:
 
 try:
 	from urllib import urlopen
+    from urllib import Request
 except ImportError:
 	from urllib.request import urlopen
+    from urllib.request import Request
 
 try:
     from io import BytesIO

--- a/fpdf/py3k.py
+++ b/fpdf/py3k.py
@@ -13,10 +13,10 @@ except ImportError:
     import pickle
 
 try:
-	from urllib import urlopen
+    from urllib import urlopen
     from urllib import Request
 except ImportError:
-	from urllib.request import urlopen
+    from urllib.request import urlopen
     from urllib.request import Request
 
 try:


### PR DESCRIPTION
### Whats the implementation ?

* Added a method _set_http_request_header_ which sets value for _http_request_header_ in the FPDF class. 
* Updated _load_resource_ to include value of _http_request_header_ with the HTTP request it makes.

### Why?
I came across a scenario in which I wanted to draw an image using FPDF#draw but since the image was protected from external access (non-browser) I was getting 403 error. 
A solution for this was to add a custom header to the request with a known browser User-agent ( like Mozilla/5.0 ).
So I added this facility which will enable users to set any custom header and it will be passed by the load_resource.

Usage
```
from fpdf import FPDF
pdf = FPDF('P',"in",(4,6))
pdf.add_page()
# below line will result in 403 since the server requires a known browser agent
pdf.image('https://clienwh.osapps.ae/assets/images/qrcodes/2202056438157048.jpg')

pdf.set_http_request_header({"User-agent": "Mozilla/5.0"})
# below line will succeed as a custom header with known browser agent is set
pdf.image('https://clienwh.osapps.ae/assets/images/qrcodes/2202056438157048.jpg')

```
