### PR TITLE
fix: deprecated dash-separated fields in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 
 [wheel]
 universal = 1


### PR DESCRIPTION
Setuptools deprecated dash-separated and uppercase fields in setup.cfg.
Ref: https://setuptools.pypa.io/en/stable/history.html#v78-0-2

Fixes #227